### PR TITLE
UICONSET-10 Select member institutions for consortia management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 * [UICONSET-18](https://issues.folio.org/browse/UICONSET-18) "Switch active affiliation" profile dropdown action.
 * [UICONSET-7](https://issues.folio.org/browse/UICONSET-7) Create "Consortium manager" interface.
 * [UICONSET-8](https://issues.folio.org/browse/UICONSET-8) Limit access to "Consortium manager" interface.
+* [UICONSET-10](https://issues.folio.org/browse/UICONSET-10) Select member institutions for consortia management.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/stripes": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@folio/stripes-acq-components": "~4.0.0",
     "@rehooks/local-storage": "^2.4.4",
+    "dom-helpers": "^3.4.0",
     "final-form": "^4.20.9",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0",

--- a/src/Root.js
+++ b/src/Root.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 import { MODULE_ROOT_ROUTE } from './constants';
+import { ConsortiumManagerContextProvider } from './contexts';
 import { eventHandler } from './eventHandler';
 import { ConsortiumManager } from './routes';
 import ConsortiumSettings from './settings';
@@ -32,12 +33,14 @@ class Root extends React.Component {
     }
 
     return (
-      <Switch>
-        <Route
-          path={MODULE_ROOT_ROUTE}
-          component={ConsortiumManager}
-        />
-      </Switch>
+      <ConsortiumManagerContextProvider>
+        <Switch>
+          <Route
+            path={MODULE_ROOT_ROUTE}
+            component={ConsortiumManager}
+          />
+        </Switch>
+      </ConsortiumManagerContextProvider>
     );
   }
 }

--- a/src/Root.test.js
+++ b/src/Root.test.js
@@ -1,14 +1,33 @@
 import { render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { noop } from 'lodash';
 import { Router } from 'react-router-dom';
 
+import { useStripes } from '@folio/stripes/core';
+
+import { affiliations } from '../test/jest/fixtures';
 import { MODULE_ROOT_ROUTE } from './constants';
+import { useUserAffiliations } from './hooks';
 import Root from './Root';
 
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useStripes: jest.fn(),
+  updateUser: jest.fn(),
+}));
+jest.mock('./hooks', () => ({
+  useUserAffiliations: jest.fn(),
+}));
 jest.mock('./settings', () => jest.fn(() => 'ConsortiumSettings'));
 jest.mock('./routes', () => ({
   ConsortiumManager: jest.fn(() => 'ConsortiumManager'),
 }));
+
+const stripes = {
+  store: {},
+  okapi: {},
+  user: {},
+};
 
 const defaultProps = {
   showSettings: false,
@@ -31,6 +50,17 @@ const renderRoot = (props = {}) => render(
 );
 
 describe('Root', () => {
+  beforeEach(() => {
+    useStripes.mockClear().mockReturnValue(stripes);
+    useUserAffiliations.mockClear().mockImplementation((_params, options) => {
+      const onSuccess = options.onSuccess || noop;
+
+      onSuccess(affiliations);
+
+      return { affiliations };
+    });
+  });
+
   afterAll(() => {
     history.replace('/');
   });

--- a/src/components/FindConsortiumMember/FindConsortiumMember.css
+++ b/src/components/FindConsortiumMember/FindConsortiumMember.css
@@ -1,0 +1,4 @@
+.modalContent {
+  padding: 0;
+  height: 80vh;
+}

--- a/src/components/FindConsortiumMember/FindConsortiumMember.js
+++ b/src/components/FindConsortiumMember/FindConsortiumMember.js
@@ -1,0 +1,87 @@
+import contains from 'dom-helpers/query/contains';
+import noop from 'lodash/noop';
+import PropTypes from 'prop-types';
+import { useCallback, useRef } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { Button } from '@folio/stripes/components';
+import { useToggle } from '@folio/stripes-acq-components';
+
+import { FindConsortiumMemberModal } from './FindConsortiumMemberModal';
+
+export const FindConsortiumMember = ({
+  disabled,
+  onClose,
+  selectRecords,
+  renderTrigger,
+  trigerless,
+  ...props
+}) => {
+  const triggerRef = useRef();
+  const modalRef = useRef();
+  const [isModalOpen, toggleModal] = useToggle(trigerless);
+
+  const onCloseModal = useCallback(() => {
+    if (
+      modalRef.current
+      && triggerRef.current
+      && contains(modalRef.current, document.activeElement)
+    ) {
+      triggerRef.current.focus();
+    }
+
+    toggleModal();
+    onClose();
+  }, [onClose, toggleModal]);
+
+  const onSave = useCallback(async (members) => {
+    await selectRecords(members);
+    toggleModal();
+  }, [selectRecords, toggleModal]);
+
+  const renderDefaultTrigger = useCallback(({ buttonRef, onClick }) => (
+    <Button
+      ref={buttonRef}
+      disabled={disabled}
+      buttonStyle="primary"
+      onClick={onClick}
+      marginBottom0
+    >
+      <FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.trigger.label" />
+    </Button>
+  ), [disabled]);
+
+  const renderTriggerButton = useCallback(() => (
+    (renderTrigger || renderDefaultTrigger)({
+      buttonRef: triggerRef,
+      onClick: toggleModal,
+    })
+  ), [renderDefaultTrigger, renderTrigger, toggleModal]);
+
+  return (
+    <>
+      {!trigerless && renderTriggerButton()}
+      {isModalOpen && (
+        <FindConsortiumMemberModal
+          onClose={onCloseModal}
+          onSave={onSave}
+          {...props}
+        />
+      )}
+    </>
+  );
+};
+
+FindConsortiumMember.defaultProps = {
+  disabled: false,
+  onClose: noop,
+  trigerless: false,
+};
+
+FindConsortiumMember.propTypes = {
+  disabled: PropTypes.bool,
+  onClose: PropTypes.func,
+  renderTrigger: PropTypes.func,
+  selectRecords: PropTypes.func.isRequired,
+  trigerless: PropTypes.bool,
+};

--- a/src/components/FindConsortiumMember/FindConsortiumMember.test.js
+++ b/src/components/FindConsortiumMember/FindConsortiumMember.test.js
@@ -1,0 +1,76 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+
+import { tenants } from '../../../test/jest/fixtures';
+import { FindConsortiumMember } from './FindConsortiumMember';
+
+const defaultProps = {
+  onClose: jest.fn(),
+  selectRecords: jest.fn(),
+  records: tenants,
+  initialSelected: [tenants[3]],
+};
+
+const renderFindConsortiumMember = (props = {}) => render(
+  <FindConsortiumMember
+    {...defaultProps}
+    {...props}
+  />,
+);
+
+describe('FindConsortiumMember', () => {
+  it('should render custom trigger', () => {
+    const triggerLabel = 'Custom name';
+
+    renderFindConsortiumMember({
+      renderTrigger: () => triggerLabel,
+    });
+
+    expect(screen.getByText(triggerLabel)).toBeInTheDocument();
+  });
+
+  describe('Modal', () => {
+    beforeEach(async () => {
+      renderFindConsortiumMember();
+      userEvent.click(await screen.findByRole('button', { name: 'ui-consortia-settings.consortiumManager.findMember.trigger.label' }));
+    });
+
+    it('should render find record modal', async () => {
+      expect(await screen.findByText('ui-consortia-settings.consortiumManager.findMember.modal.title')).toBeInTheDocument();
+    });
+
+    it('should close modal when \'Cancel\' button was clicked', async () => {
+      userEvent.click(await screen.findByText('stripes-core.button.cancel'));
+
+      expect(screen.queryByText('ui-consortia-settings.consortiumManager.findMember.modal.title')).not.toBeInTheDocument();
+    });
+
+    it('should handle selected records when \'Save & close\' button was clicked', async () => {
+      userEvent.click(await screen.findByText('stripes-components.saveAndClose'));
+
+      expect(defaultProps.selectRecords).toHaveBeenCalled();
+    });
+
+    describe('Filters', () => {
+      it('should filter results by search query', async () => {
+        expect(await screen.findAllByRole('row')).toHaveLength(tenants.length + 1);
+
+        userEvent.type(await screen.findByLabelText('ui-consortia-settings.consortiumManager.findMember.modal.aria.search'), tenants[0].name);
+        userEvent.click(await screen.findByText('stripes-acq-components.search'));
+
+        expect(await screen.findAllByRole('row')).toHaveLength(2);
+      });
+
+      it('should reset filters when \'Reset all\' button was clicked', async () => {
+        userEvent.type(await screen.findByLabelText('ui-consortia-settings.consortiumManager.findMember.modal.aria.search'), 'Community');
+        userEvent.click(await screen.findByText('stripes-acq-components.search'));
+
+        expect(await screen.findAllByRole('row')).toHaveLength(3);
+
+        userEvent.click(await screen.findByTestId('reset-button'));
+
+        expect(await screen.findAllByRole('row')).toHaveLength(tenants.length + 1);
+      });
+    });
+  });
+});

--- a/src/components/FindConsortiumMember/FindConsortiumMemberModal/FindConsortiumMemberModal.js
+++ b/src/components/FindConsortiumMember/FindConsortiumMemberModal/FindConsortiumMemberModal.js
@@ -145,7 +145,7 @@ export const FindConsortiumMemberModal = ({
       contentClass={css.modalContent}
       dismissible
       footer={footer}
-      label={<FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.trigger.label" />}
+      label={<FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.modal.title" />}
       onClose={onClose}
       size="large"
       showHeader

--- a/src/components/FindConsortiumMember/FindConsortiumMemberModal/FindConsortiumMemberModal.js
+++ b/src/components/FindConsortiumMember/FindConsortiumMemberModal/FindConsortiumMemberModal.js
@@ -1,0 +1,223 @@
+import noop from 'lodash/noop';
+import PropTypes from 'prop-types';
+import { useCallback, useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+  Checkbox,
+  Layout,
+  MessageBanner,
+  Modal,
+  Paneset,
+} from '@folio/stripes/components';
+import {
+  FiltersPane,
+  FrontendSortingMCL,
+  ResetButton,
+  ResultsPane,
+  SEARCH_PARAMETER,
+  SingleSearchForm,
+  useFilters,
+  useToggle,
+} from '@folio/stripes-acq-components';
+
+import {
+  MEMBERS_COLUMN_NAMES,
+  MEMBERS_COLUMN_WIDTHS,
+  MEMBERS_VISIBLE_COLUMNS,
+} from '../constants';
+
+import css from '../FindConsortiumMember.css';
+import { useRecordsSelect } from '../useRecordsSelect';
+
+const getColumnMapping = ({ isAllSelected, selectAll }) => ({
+  selected: (
+    <FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.modal.aria.selectAll">
+      {label => (
+        <Checkbox
+          aria-label={label}
+          checked={isAllSelected}
+          onChange={selectAll}
+        />
+      )}
+    </FormattedMessage>
+  ),
+  name: <FormattedMessage id="ui-consortia-settings.settings.membership.list.tenantName" />,
+});
+
+const getResultFormatter = ({ select, selectedRecordsMap }) => ({
+  selected: member => (
+    <FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.modal.aria.select">
+      {label => (
+        <Checkbox
+          aria-label={label}
+          checked={Boolean(selectedRecordsMap[member.id])}
+          onChange={() => select(member)}
+        />
+      )}
+    </FormattedMessage>
+  ),
+  name: member => member.name,
+});
+
+const sorters = {
+  [MEMBERS_COLUMN_NAMES.name]: ({ name }) => name.toLocaleLowerCase(),
+};
+
+export const FindConsortiumMemberModal = ({
+  initialSelected,
+  onClose,
+  onSave,
+  records,
+  resetData,
+}) => {
+  const [isFiltersVisible, toggleFilters] = useToggle(true);
+
+  const {
+    filters,
+    searchQuery,
+    applyFilters,
+    applySearch,
+    changeSearch,
+    resetFilters,
+  } = useFilters(resetData);
+
+  const {
+    isAllSelected,
+    select,
+    selectAll,
+    selectedRecordsMap,
+    totalSelected,
+  } = useRecordsSelect({ records, initialSelected });
+
+  const handleSave = useCallback(() => {
+    onSave(records.filter(({ id }) => selectedRecordsMap[id]));
+  }, [onSave, records, selectedRecordsMap]);
+
+  const footer = (
+    <Layout className="display-flex justified full">
+      <Button
+        id="clickable-find-consortium-member-modal-cancel"
+        onClick={onClose}
+        marginBottom0
+      >
+        <FormattedMessage id="stripes-core.button.cancel" />
+      </Button>
+      <div>
+        <FormattedMessage
+          id="ui-consortia-settings.consortiumManager.findMember.modal.results.totalSelected"
+          values={{ amount: totalSelected }}
+        />
+      </div>
+      <Button
+        id="clickable-find-consortium-member-modal-submit"
+        marginBottom0
+        buttonStyle="primary"
+        onClick={handleSave}
+      >
+        <FormattedMessage id="stripes-components.saveAndClose" />
+      </Button>
+    </Layout>
+  );
+
+  const columnMapping = useMemo(() => getColumnMapping({ isAllSelected, selectAll }), [isAllSelected, selectAll]);
+  const formatter = useMemo(() => getResultFormatter({ select, selectedRecordsMap }), [select, selectedRecordsMap]);
+
+  const query = filters[SEARCH_PARAMETER];
+  const contentData = useMemo(() => (
+    records.filter(({ name }) => (
+      query ? name.toLowerCase().includes(query.toLowerCase()) : true
+    ))
+  ), [query, records]);
+
+  const onChangeSearch = useCallback((e) => {
+    changeSearch(e);
+    if (!e.target.value) {
+      applyFilters([SEARCH_PARAMETER], undefined);
+    }
+  }, [applyFilters, changeSearch]);
+
+  return (
+    <Modal
+      open
+      id="find-consortium-member-modal"
+      contentClass={css.modalContent}
+      dismissible
+      footer={footer}
+      label={<FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.trigger.label" />}
+      onClose={onClose}
+      size="large"
+      showHeader
+    >
+      <Paneset isRoot static>
+        {isFiltersVisible && (
+          <FiltersPane
+            id="find-consortium-member-filters-pane"
+            toggleFilters={toggleFilters}
+          >
+            <SingleSearchForm
+              applySearch={applySearch}
+              changeSearch={onChangeSearch}
+              searchQuery={searchQuery}
+              ariaLabelId="ui-consortia-settings.consortiumManager.findMember.modal.aria.search"
+            />
+
+            <ResetButton
+              reset={resetFilters}
+              disabled={!searchQuery}
+            />
+          </FiltersPane>
+        )}
+
+        <ResultsPane
+          title={<FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.modal.results.title" />}
+          subTitle={(
+            <FormattedMessage
+              id="ui-consortia-settings.consortiumManager.findMember.modal.results.subTitle"
+              values={{ amount: contentData.length }}
+            />
+          )}
+          count={contentData.length}
+          toggleFiltersPane={toggleFilters}
+          filters={filters}
+          isFiltersOpened={isFiltersVisible}
+        >
+          <MessageBanner type="warning">
+            <FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.modal.results.warning" />
+          </MessageBanner>
+          <FrontendSortingMCL
+            id="find-consortium-member-list"
+            columnIdPrefix="consortium-manager"
+            columnMapping={columnMapping}
+            contentData={contentData}
+            columnWidths={MEMBERS_COLUMN_WIDTHS}
+            formatter={formatter}
+            sortedColumn={MEMBERS_COLUMN_NAMES.name}
+            sorters={sorters}
+            visibleColumns={MEMBERS_VISIBLE_COLUMNS}
+          />
+        </ResultsPane>
+      </Paneset>
+    </Modal>
+  );
+};
+
+FindConsortiumMemberModal.defaultProps = {
+  initialSelected: [],
+  records: [],
+  resetData: noop,
+};
+
+const recordShape = PropTypes.shape({
+  id: PropTypes.string,
+  name: PropTypes.string,
+});
+
+FindConsortiumMemberModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  records: PropTypes.arrayOf(recordShape),
+  resetData: PropTypes.func,
+  initialSelected: PropTypes.arrayOf(recordShape),
+};

--- a/src/components/FindConsortiumMember/FindConsortiumMemberModal/index.js
+++ b/src/components/FindConsortiumMember/FindConsortiumMemberModal/index.js
@@ -1,0 +1,1 @@
+export { FindConsortiumMemberModal } from './FindConsortiumMemberModal';

--- a/src/components/FindConsortiumMember/constants.js
+++ b/src/components/FindConsortiumMember/constants.js
@@ -1,0 +1,13 @@
+export const MEMBERS_COLUMN_NAMES = {
+  selected: 'selected',
+  name: 'name',
+};
+
+export const MEMBERS_VISIBLE_COLUMNS = [
+  MEMBERS_COLUMN_NAMES.selected,
+  MEMBERS_COLUMN_NAMES.name,
+];
+
+export const MEMBERS_COLUMN_WIDTHS = {
+  [MEMBERS_COLUMN_NAMES.selected]: '35px',
+};

--- a/src/components/FindConsortiumMember/index.js
+++ b/src/components/FindConsortiumMember/index.js
@@ -1,0 +1,1 @@
+export { FindConsortiumMember } from './FindConsortiumMember';

--- a/src/components/FindConsortiumMember/useRecordsSelect.js
+++ b/src/components/FindConsortiumMember/useRecordsSelect.js
@@ -1,0 +1,45 @@
+import keyBy from 'lodash/keyBy';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export const useRecordsSelect = ({ records, initialSelected }) => {
+  const [selectedRecordsMap, setSelectedRecordsMap] = useState({});
+
+  useEffect(() => {
+    setSelectedRecordsMap(() => {
+      const initialSelectedMap = keyBy(initialSelected, 'id');
+
+      return records.reduce((acc, { id }) => ({ ...acc, [id]: Boolean(initialSelectedMap[id]) }), {});
+    });
+  }, [initialSelected, records]);
+
+  const isAllSelected = useMemo(() => (
+    Object.values(selectedRecordsMap).every(value => Boolean(value))
+  ), [selectedRecordsMap]);
+
+  const totalSelected = useMemo(() => (
+    Object.values(selectedRecordsMap).filter(Boolean).length
+  ), [selectedRecordsMap]);
+
+  const select = useCallback(({ id }) => {
+    setSelectedRecordsMap(prev => ({ ...prev, [id]: !prev[id] }));
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelectedRecordsMap(prev => (
+      Object.entries(prev).reduce((acc, [key]) => ({ ...acc, [key]: !isAllSelected }), {})
+    ));
+  }, [isAllSelected]);
+
+  return {
+    selectedRecordsMap,
+    isAllSelected,
+    select,
+    selectAll,
+    totalSelected,
+  };
+};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,1 +1,2 @@
+export { FindConsortiumMember } from './FindConsortiumMember';
 export { SwitchActiveAffiliation } from './SwitchActiveAffiliation';

--- a/src/contexts/ConsortiumContext.js
+++ b/src/contexts/ConsortiumContext.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { createContext, useMemo } from 'react';
 
-import { useCurrentConsortium } from './hooks';
+import { useCurrentConsortium } from '../hooks';
 
 export const ConsortiumContext = createContext();
 

--- a/src/contexts/ConsortiumManagerContext.js
+++ b/src/contexts/ConsortiumManagerContext.js
@@ -1,0 +1,61 @@
+import PropTypes from 'prop-types';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
+
+import {
+  updateUser,
+  useStripes,
+} from '@folio/stripes/core';
+
+import { useUserAffiliations } from '../hooks';
+
+export const ConsortiumManagerContext = createContext();
+
+export const ConsortiumManagerContextProvider = ({ children }) => {
+  const stripes = useStripes();
+  const [selectMembersDisabled, setSelectMembersDisabled] = useState();
+  const selectedMembers = stripes?.user?.user?.selectedConsortiumMembers;
+
+  const selectMembers = useCallback(async (members) => {
+    await updateUser(stripes.store, {
+      selectedConsortiumMembers: members,
+    });
+  }, [stripes.store]);
+
+  const initSelectedMembers = useCallback(async (data) => {
+    if (!selectedMembers) {
+      await selectMembers(
+        data.map(({ tenantId, tenantName }) => ({ id: tenantId, name: tenantName })),
+      );
+    }
+  }, [selectedMembers, selectMembers]);
+
+  const { affiliations } = useUserAffiliations(
+    { userId: stripes?.user?.user?.id },
+    { onSuccess: initSelectedMembers },
+  );
+
+  const value = {
+    affiliations,
+    selectedMembers,
+    selectMembers,
+    selectMembersDisabled,
+    setSelectMembersDisabled,
+  };
+
+  return (
+    <ConsortiumManagerContext.Provider value={value}>
+      {children}
+    </ConsortiumManagerContext.Provider>
+  );
+};
+
+ConsortiumManagerContextProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export const useConsortiumManagerContext = () => useContext(ConsortiumManagerContext);

--- a/src/contexts/ConsortiumManagerContext.js
+++ b/src/contexts/ConsortiumManagerContext.js
@@ -3,6 +3,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useMemo,
   useState,
 } from 'react';
 
@@ -39,16 +40,21 @@ export const ConsortiumManagerContextProvider = ({ children }) => {
     { onSuccess: initSelectedMembers },
   );
 
-  const value = {
+  const contextValue = useMemo(() => ({
     affiliations,
     selectedMembers,
     selectMembers,
     selectMembersDisabled,
     setSelectMembersDisabled,
-  };
+  }), [
+    affiliations,
+    selectMembers,
+    selectMembersDisabled,
+    selectedMembers,
+  ]);
 
   return (
-    <ConsortiumManagerContext.Provider value={value}>
+    <ConsortiumManagerContext.Provider value={contextValue}>
       {children}
     </ConsortiumManagerContext.Provider>
   );

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,0 +1,9 @@
+export {
+  ConsortiumContext,
+  ConsortiumContextProvider,
+} from './ConsortiumContext';
+export {
+  ConsortiumManagerContext,
+  ConsortiumManagerContextProvider,
+  useConsortiumManagerContext,
+} from './ConsortiumManagerContext';

--- a/src/routes/ConsortiumManager.js
+++ b/src/routes/ConsortiumManager.js
@@ -1,3 +1,47 @@
+import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Pane,
+  Paneset,
+} from '@folio/stripes/components';
+
+import { FindConsortiumMember } from '../components';
+import { useConsortiumManagerContext } from '../contexts';
+
 export const ConsortiumManager = () => {
-  return 'Consortium Manager';
+  const {
+    affiliations,
+    selectedMembers,
+    selectMembers,
+    selectMembersDisabled,
+  } = useConsortiumManagerContext();
+
+  const records = useMemo(() => (
+    affiliations.map(({ tenantId, tenantName }) => ({ id: tenantId, name: tenantName }))
+  ), [affiliations]);
+
+  return (
+    <Paneset>
+      <Pane
+        paneTitle={<FormattedMessage id="ui-consortia-settings.consortiumManager.members.header.title" />}
+        paneSub={Boolean(selectedMembers) && (
+          <FormattedMessage
+            id="ui-consortia-settings.consortiumManager.members.header.subTitle"
+            values={{ amount: selectedMembers.length }}
+          />
+        )}
+        lastMenu={(
+          <FindConsortiumMember
+            disabled={selectMembersDisabled}
+            records={records}
+            initialSelected={selectedMembers}
+            selectRecords={selectMembers}
+          />
+        )}
+      >
+        Consortium Manager
+      </Pane>
+    </Paneset>
+  );
 };

--- a/src/routes/ConsortiumManager.js
+++ b/src/routes/ConsortiumManager.js
@@ -24,6 +24,7 @@ export const ConsortiumManager = () => {
   return (
     <Paneset>
       <Pane
+        defaultWidth="fill"
         paneTitle={<FormattedMessage id="ui-consortia-settings.consortiumManager.members.header.title" />}
         paneSub={Boolean(selectedMembers) && (
           <FormattedMessage

--- a/src/routes/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager.test.js
@@ -1,14 +1,34 @@
 import { render, screen } from '@testing-library/react';
 
+import { tenants } from '../../test/jest/fixtures';
+import { ConsortiumManagerContext } from '../contexts';
 import { ConsortiumManager } from './ConsortiumManager';
 
+const affiliations = tenants.map(({ id, name }) => ({
+  tenantId: id,
+  tenantName: name,
+}));
+
 const defaultProps = {};
+const context = {
+  affiliations,
+  selectedMembers: tenants.slice(3),
+  selectMembers: jest.fn(),
+  selectMembersDisabled: false,
+};
+
+const wrapper = ({ children }) => (
+  <ConsortiumManagerContext.Provider value={context}>
+    {children}
+  </ConsortiumManagerContext.Provider>
+);
 
 const renderConsortiumManager = (props = {}) => render(
   <ConsortiumManager
     {...defaultProps}
     {...props}
   />,
+  { wrapper },
 );
 
 describe('ConsortiumManager', () => {

--- a/src/routes/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager.test.js
@@ -1,13 +1,8 @@
 import { render, screen } from '@testing-library/react';
 
-import { tenants } from '../../test/jest/fixtures';
+import { affiliations, tenants } from '../../test/jest/fixtures';
 import { ConsortiumManagerContext } from '../contexts';
 import { ConsortiumManager } from './ConsortiumManager';
-
-const affiliations = tenants.map(({ id, name }) => ({
-  tenantId: id,
-  tenantName: name,
-}));
 
 const defaultProps = {};
 const context = {

--- a/src/routes/ConsortiumManager/ConsortiumManager.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.js
@@ -6,8 +6,8 @@ import {
   Paneset,
 } from '@folio/stripes/components';
 
-import { FindConsortiumMember } from '../components';
-import { useConsortiumManagerContext } from '../contexts';
+import { FindConsortiumMember } from '../../components';
+import { useConsortiumManagerContext } from '../../contexts';
 
 export const ConsortiumManager = () => {
   const {

--- a/src/routes/ConsortiumManager/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
-import { affiliations, tenants } from '../../test/jest/fixtures';
-import { ConsortiumManagerContext } from '../contexts';
+import { affiliations, tenants } from '../../../test/jest/fixtures';
+import { ConsortiumManagerContext } from '../../contexts';
 import { ConsortiumManager } from './ConsortiumManager';
 
 const defaultProps = {};

--- a/src/routes/ConsortiumManager/index.js
+++ b/src/routes/ConsortiumManager/index.js
@@ -1,0 +1,1 @@
+export { ConsortiumManager } from './ConsortiumManager';

--- a/src/settings/ConsortiumSettings/ConsortiumSettings.js
+++ b/src/settings/ConsortiumSettings/ConsortiumSettings.js
@@ -7,7 +7,7 @@ import {
 } from '@folio/stripes/components';
 import { Settings } from '@folio/stripes/smart-components';
 
-import { ConsortiumContextProvider } from '../../ConsortiumContext';
+import { ConsortiumContextProvider } from '../../contexts';
 import { Membership } from '../Membership';
 
 const sections = [

--- a/src/withConsortium.js
+++ b/src/withConsortium.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ConsortiumContext } from './ConsortiumContext';
+import { ConsortiumContext } from './contexts';
 
 export const withConsortium = (WrappedComponent) => {
   return class extends React.Component {

--- a/test/jest/fixtures/affiliations.js
+++ b/test/jest/fixtures/affiliations.js
@@ -1,0 +1,10 @@
+import { tenants } from './tenants';
+
+export const affiliations = tenants.map(({ id, name }, i) => ({
+  id: `affiliation-${i}`,
+  tenantId: id,
+  tenantName: name,
+  username: 'testuser',
+  userId: 'user-id',
+  isPrimary: i === 1,
+}));

--- a/test/jest/fixtures/index.js
+++ b/test/jest/fixtures/index.js
@@ -1,2 +1,3 @@
+export * from './affiliations';
 export * from './consortium';
 export * from './tenants';

--- a/translations/ui-consortia-settings/en.json
+++ b/translations/ui-consortia-settings/en.json
@@ -5,6 +5,17 @@
 
   "button.saveAndClose": "Save & close",
 
+  "consortiumManager.findMember.trigger.label": "Select members",
+  "consortiumManager.findMember.modal.results.subTitle": "{amount, plural, one {# member} other {# members}} found",
+  "consortiumManager.findMember.modal.results.title": "Members",
+  "consortiumManager.findMember.modal.results.totalSelected": "Total selected: {amount}",
+  "consortiumManager.findMember.modal.results.warning": "Settings for the following selected members can be modified at the same time.",
+  "consortiumManager.findMember.modal.aria.search": "Search members",
+  "consortiumManager.findMember.modal.aria.select": "Select member",
+  "consortiumManager.findMember.modal.aria.selectAll": "Select all members",
+  "consortiumManager.members.header.subTitle": "{amount, plural, one {# member} other {# members}} selected",
+  "consortiumManager.members.header.title": "Settings for selected members can be modified at the same time",
+
   "settings.heading": "Network settings",
   "settings.section.general": "General",
 

--- a/translations/ui-consortia-settings/en.json
+++ b/translations/ui-consortia-settings/en.json
@@ -6,13 +6,14 @@
   "button.saveAndClose": "Save & close",
 
   "consortiumManager.findMember.trigger.label": "Select members",
+  "consortiumManager.findMember.modal.aria.search": "Search members",
+  "consortiumManager.findMember.modal.aria.select": "Select member",
+  "consortiumManager.findMember.modal.aria.selectAll": "Select all members",
   "consortiumManager.findMember.modal.results.subTitle": "{amount, plural, one {# member} other {# members}} found",
   "consortiumManager.findMember.modal.results.title": "Members",
   "consortiumManager.findMember.modal.results.totalSelected": "Total selected: {amount}",
   "consortiumManager.findMember.modal.results.warning": "Settings for the following selected members can be modified at the same time.",
-  "consortiumManager.findMember.modal.aria.search": "Search members",
-  "consortiumManager.findMember.modal.aria.select": "Select member",
-  "consortiumManager.findMember.modal.aria.selectAll": "Select all members",
+  "consortiumManager.findMember.modal.title": "Select members",
   "consortiumManager.members.header.subTitle": "{amount, plural, one {# member} other {# members}} selected",
   "consortiumManager.members.header.title": "Settings for selected members can be modified at the same time",
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UICONSET-10

When defining consortia settings, defaults and configurations, authorized consortia staff need to select some or all member libraries with which to associate a given setting, default and/or configuration. Staff require an interface to designate affected member institutions.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- wrap consortium manager in react context to store selected members' data;
- implement a modal to select consortium members;
- keep selected members in session (until the user is logged out);
- add unit tests.

![chrome_QVwK23LGmN](https://github.com/folio-org/ui-consortia-settings/assets/88109087/b9f23b46-1cb2-41fd-86aa-12fc66ab3f7e)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
