### PR TITLE
UICONSET-26 Set consortium manager settings section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 * [UICONSET-7](https://issues.folio.org/browse/UICONSET-7) Create "Consortium manager" interface.
 * [UICONSET-8](https://issues.folio.org/browse/UICONSET-8) Limit access to "Consortium manager" interface.
 * [UICONSET-10](https://issues.folio.org/browse/UICONSET-10) Select member institutions for consortia management.
+* [UICONSET-26](https://issues.folio.org/browse/UICONSET-26) Set consortium manager settings section.

--- a/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.css
+++ b/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.css
@@ -1,0 +1,5 @@
+@import "@folio/stripes-components/lib/sharedStyles/focusWithinIndicator";
+
+.managerHeader {
+  composes: focusWithinIndicator;
+}

--- a/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.js
+++ b/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.js
@@ -1,15 +1,18 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {
-  Pane,
+  PaneHeader,
   Paneset,
 } from '@folio/stripes/components';
 
 import { useConsortiumManagerContext } from '../../contexts';
 import { FindConsortiumMember } from '../FindConsortiumMember';
 
+import css from './ConsortiumManagerHeader.css';
+
 export const ConsortiumManagerHeader = () => {
+  const paneTitleRef = useRef();
   const {
     affiliations,
     selectedMembers,
@@ -22,9 +25,11 @@ export const ConsortiumManagerHeader = () => {
   ), [affiliations]);
 
   return (
-    <Paneset isRoot static>
-      <Pane
-        defaultWidth="fill"
+    <Paneset nested>
+      <PaneHeader
+        id="consortium-manager-header"
+        className={css.managerHeader}
+        paneTitleRef={paneTitleRef}
         paneTitle={<FormattedMessage id="ui-consortia-settings.consortiumManager.members.header.title" />}
         paneSub={Boolean(selectedMembers) && (
           <FormattedMessage
@@ -40,7 +45,6 @@ export const ConsortiumManagerHeader = () => {
             selectRecords={selectMembers}
           />
         )}
-        padContent={false}
       />
     </Paneset>
   );

--- a/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.js
+++ b/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.js
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Pane,
+  Paneset,
+} from '@folio/stripes/components';
+
+import { useConsortiumManagerContext } from '../../contexts';
+import { FindConsortiumMember } from '../FindConsortiumMember';
+
+export const ConsortiumManagerHeader = () => {
+  const {
+    affiliations,
+    selectedMembers,
+    selectMembers,
+    selectMembersDisabled,
+  } = useConsortiumManagerContext();
+
+  const records = useMemo(() => (
+    affiliations.map(({ tenantId, tenantName }) => ({ id: tenantId, name: tenantName }))
+  ), [affiliations]);
+
+  return (
+    <Paneset isRoot static>
+      <Pane
+        defaultWidth="fill"
+        paneTitle={<FormattedMessage id="ui-consortia-settings.consortiumManager.members.header.title" />}
+        paneSub={Boolean(selectedMembers) && (
+          <FormattedMessage
+            id="ui-consortia-settings.consortiumManager.members.header.subTitle"
+            values={{ amount: selectedMembers.length }}
+          />
+        )}
+        lastMenu={(
+          <FindConsortiumMember
+            disabled={selectMembersDisabled}
+            records={records}
+            initialSelected={selectedMembers}
+            selectRecords={selectMembers}
+          />
+        )}
+        padContent={false}
+      />
+    </Paneset>
+  );
+};

--- a/src/components/ConsortiumManagerHeader/index.js
+++ b/src/components/ConsortiumManagerHeader/index.js
@@ -1,0 +1,1 @@
+export { ConsortiumManagerHeader } from './ConsortiumManagerHeader';

--- a/src/components/FindConsortiumMember/FindConsortiumMemberModal/FindConsortiumMemberModal.js
+++ b/src/components/FindConsortiumMember/FindConsortiumMemberModal/FindConsortiumMemberModal.js
@@ -182,6 +182,7 @@ export const FindConsortiumMemberModal = ({
           toggleFiltersPane={toggleFilters}
           filters={filters}
           isFiltersOpened={isFiltersVisible}
+          padContent
         >
           <MessageBanner type="warning">
             <FormattedMessage id="ui-consortia-settings.consortiumManager.findMember.modal.results.warning" />

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,3 @@
+export { ConsortiumManagerHeader } from './ConsortiumManagerHeader';
 export { FindConsortiumMember } from './FindConsortiumMember';
 export { SwitchActiveAffiliation } from './SwitchActiveAffiliation';

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,3 +11,5 @@ export const CONSORTIA_TENANTS_API = 'tenants';
 export const CONSORTIA_USER_TENANTS_API = 'user-tenants';
 
 export const MODULE_ROOT_ROUTE = stripesConfig.route;
+
+export const PACKAGE_SCOPE_REGEX = /^@[a-z\d][\w-.]{0,214}\//;

--- a/src/routes/ConsortiumManager/ConsortiumManager.css
+++ b/src/routes/ConsortiumManager/ConsortiumManager.css
@@ -1,0 +1,22 @@
+@import "@folio/stripes-components/lib/variables";
+
+.managerContent {
+  position: relative;
+  height: calc(100vh - var(--control-min-size-touch) - 56px);
+}
+
+@media (--medium-down) {
+  .managerContent {
+    min-height: calc(100vh - var(--control-min-size-touch) - 48px);
+  }
+}
+
+.settingChoose {
+  padding: var(--gutter);
+  flex: auto;
+}
+
+.panePlaceholder {
+  background-color: var(--color-fill);
+  flex: auto;
+}

--- a/src/routes/ConsortiumManager/ConsortiumManager.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.js
@@ -1,48 +1,124 @@
-import { useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
+import ReactRouterPropTypes from 'react-router-prop-types';
+import { Suspense, useMemo } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { Route, Switch } from 'react-router-dom';
 
 import {
+  AppIcon,
+  useModules,
+} from '@folio/stripes/core';
+import {
+  LoadingPane,
+  NavList,
+  NavListItem,
+  NavListSection,
   Pane,
   Paneset,
 } from '@folio/stripes/components';
 
-import { FindConsortiumMember } from '../../components';
-import { useConsortiumManagerContext } from '../../contexts';
+import { ConsortiumManagerHeader } from '../../components';
+import { MODULE_ROOT_ROUTE } from '../../constants';
+import { getModuleName } from '../../utils';
+import { SETTINGS_ROUTES } from './constants';
 
-export const ConsortiumManager = () => {
-  const {
-    affiliations,
-    selectedMembers,
-    selectMembers,
-    selectMembersDisabled,
-  } = useConsortiumManagerContext();
+import css from './ConsortiumManager.css';
 
-  const records = useMemo(() => (
-    affiliations.map(({ tenantId, tenantName }) => ({ id: tenantId, name: tenantName }))
-  ), [affiliations]);
+const ChooseSettings = () => (
+  <div className={css.settingChoose}>
+    <FormattedMessage id="stripes-core.settingChoose" />
+  </div>
+);
+
+const PanePlaceholder = () => <div className={css.panePlaceholder} />;
+
+export const ConsortiumManager = ({ location }) => {
+  const intl = useIntl();
+  const modules = useModules();
+
+  const activeLink = `${MODULE_ROOT_ROUTE}/${location.pathname.split('/')[2]}`;
+
+  const settings = useMemo(() => (
+    modules.settings
+      .filter((m) => Boolean(SETTINGS_ROUTES[getModuleName(m)]))
+      .sort((x, y) => x.displayName.toLowerCase().localeCompare(y.displayName.toLowerCase()))
+  ), [modules.settings]);
+
+  const navLinks = useMemo(() => (
+    settings.map(({ displayName, module: name, route }) => (
+      <NavListItem
+        key={route}
+        to={`${MODULE_ROOT_ROUTE}${route}`}
+      >
+        <AppIcon
+          alt={displayName}
+          app={name}
+          size="small"
+        >
+          {displayName}
+        </AppIcon>
+      </NavListItem>
+    ))
+  ), [settings]);
+
+  const routes = useMemo(() => (
+    settings.map((m) => (
+      <Route
+        path={`${MODULE_ROOT_ROUTE}${m.route}`}
+        key={m.route}
+        render={(props) => {
+          const Component = SETTINGS_ROUTES[getModuleName(m)];
+
+          return (
+            <>
+              <Component {...props} />
+              {/* eslint-disable-next-line react/prop-types */}
+              {props.match.isExact ? <PanePlaceholder /> : null}
+            </>
+          );
+        }}
+      />
+    ))
+  ), [settings]);
 
   return (
-    <Paneset>
-      <Pane
-        defaultWidth="fill"
-        paneTitle={<FormattedMessage id="ui-consortia-settings.consortiumManager.members.header.title" />}
-        paneSub={Boolean(selectedMembers) && (
-          <FormattedMessage
-            id="ui-consortia-settings.consortiumManager.members.header.subTitle"
-            values={{ amount: selectedMembers.length }}
-          />
-        )}
-        lastMenu={(
-          <FindConsortiumMember
-            disabled={selectMembersDisabled}
-            records={records}
-            initialSelected={selectedMembers}
-            selectRecords={selectMembers}
-          />
-        )}
-      >
-        Consortium Manager
-      </Pane>
-    </Paneset>
+    <>
+      <ConsortiumManagerHeader />
+      <div className={css.managerContent}>
+        <Paneset isRoot>
+          <Pane
+            defaultWidth="20%"
+            paneTitle={<FormattedMessage id="stripes-core.settings" />}
+            id="settings-nav-pane"
+          >
+            <NavList aria-label={intl.formatMessage({ id: 'stripes-core.settings' })}>
+              <NavListSection
+                activeLink={activeLink}
+                label={intl.formatMessage({ id: 'stripes-core.settings' })}
+                className={css.navListSection}
+              >
+                {navLinks}
+              </NavListSection>
+            </NavList>
+          </Pane>
+          <Suspense
+            fallback={(
+              <>
+                <LoadingPane defaultWidth="30%" />
+                <PanePlaceholder />
+              </>
+            )}
+          >
+            <Switch>
+              {routes}
+              <Route component={ChooseSettings} />
+            </Switch>
+          </Suspense>
+        </Paneset>
+      </div>
+    </>
   );
+};
+
+ConsortiumManager.propTypes = {
+  location: ReactRouterPropTypes.location.isRequired,
 };

--- a/src/routes/ConsortiumManager/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.test.js
@@ -1,5 +1,6 @@
-import { MemoryRouter, withRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter, withRouter } from 'react-router-dom';
 
 import { useModules } from '@folio/stripes/core';
 
@@ -23,7 +24,7 @@ const context = {
 
 const modules = {
   settings: AVAILABLE_SETTINGS.map((module) => ({
-    displayName: module.toLocaleUpperCase(),
+    displayName: module,
     module,
     route: `/${module}`,
   })),
@@ -46,6 +47,14 @@ const renderConsortiumManager = (props = {}) => render(
   { wrapper },
 );
 
+const settingsLabelsMap = {
+  circulation: 'ui-circulation.settings.index.paneTitle',
+  'data-export': 'ui-data-export.settings.index.paneTitle',
+  'data-import': 'ui-data-import.settings.index.paneTitle',
+  inventory: 'ui-inventory.inventory.label',
+  users: 'ui-users.settings.label',
+};
+
 describe('ConsortiumManager', () => {
   beforeEach(() => {
     useModules.mockClear().mockReturnValue(modules);
@@ -55,5 +64,21 @@ describe('ConsortiumManager', () => {
     renderConsortiumManager();
 
     expect(screen.getByText('ui-consortia-settings.consortiumManager.members.header.title')).toBeInTheDocument();
+  });
+
+  it('should render consortium manager settings nav links', () => {
+    renderConsortiumManager();
+
+    AVAILABLE_SETTINGS.forEach(module => {
+      expect(screen.getByText(module)).toBeInTheDocument();
+    });
+  });
+
+  it.each(AVAILABLE_SETTINGS.map(module => [module]))('should render \'%s\' settings pane', async (name) => {
+    renderConsortiumManager();
+
+    userEvent.click(screen.getByText(name));
+
+    expect(await screen.findByText(settingsLabelsMap[name])).toBeInTheDocument();
   });
 });

--- a/src/routes/ConsortiumManager/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.test.js
@@ -1,8 +1,17 @@
+import { MemoryRouter, withRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
+
+import { useModules } from '@folio/stripes/core';
 
 import { affiliations, tenants } from '../../../test/jest/fixtures';
 import { ConsortiumManagerContext } from '../../contexts';
 import { ConsortiumManager } from './ConsortiumManager';
+import { AVAILABLE_SETTINGS } from './constants';
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useModules: jest.fn(),
+}));
 
 const defaultProps = {};
 const context = {
@@ -12,14 +21,25 @@ const context = {
   selectMembersDisabled: false,
 };
 
+const modules = {
+  settings: AVAILABLE_SETTINGS.map((module) => ({
+    displayName: module.toLocaleUpperCase(),
+    module,
+    route: `/${module}`,
+  })),
+};
+
 const wrapper = ({ children }) => (
-  <ConsortiumManagerContext.Provider value={context}>
-    {children}
-  </ConsortiumManagerContext.Provider>
+  <MemoryRouter>
+    <ConsortiumManagerContext.Provider value={context}>
+      {children}
+    </ConsortiumManagerContext.Provider>
+  </MemoryRouter>
 );
 
+const TestComponent = withRouter(ConsortiumManager);
 const renderConsortiumManager = (props = {}) => render(
-  <ConsortiumManager
+  <TestComponent
     {...defaultProps}
     {...props}
   />,
@@ -27,9 +47,13 @@ const renderConsortiumManager = (props = {}) => render(
 );
 
 describe('ConsortiumManager', () => {
+  beforeEach(() => {
+    useModules.mockClear().mockReturnValue(modules);
+  });
+
   it('should render ConsortiumManager', () => {
     renderConsortiumManager();
 
-    expect(screen.getByText('Consortium Manager')).toBeInTheDocument();
+    expect(screen.getByText('ui-consortia-settings.consortiumManager.members.header.title')).toBeInTheDocument();
   });
 });

--- a/src/routes/ConsortiumManager/constants.js
+++ b/src/routes/ConsortiumManager/constants.js
@@ -1,0 +1,15 @@
+import { lazy } from 'react';
+
+export const AVAILABLE_SETTINGS = [
+  'circulation',
+  'data-export',
+  'data-import',
+  'inventory',
+  'users',
+];
+
+export const SETTINGS_ROUTES = AVAILABLE_SETTINGS.reduce((acc, curr) => {
+  acc[curr] = lazy(async () => import(`./settings/${curr}`));
+
+  return acc;
+}, {});

--- a/src/routes/ConsortiumManager/settings/circulation/CirculationSettings.js
+++ b/src/routes/ConsortiumManager/settings/circulation/CirculationSettings.js
@@ -1,0 +1,20 @@
+import { FormattedMessage } from 'react-intl';
+
+import { stripesShape } from '@folio/stripes/core';
+import { Settings } from '@folio/stripes/smart-components';
+
+const CirculationSettings = (props) => {
+  return (
+    <Settings
+      {...props}
+      sections={[]}
+      paneTitle={<FormattedMessage id="ui-circulation.settings.index.paneTitle" />}
+    />
+  );
+};
+
+CirculationSettings.propTypes = {
+  stripes: stripesShape.isRequired,
+};
+
+export default CirculationSettings;

--- a/src/routes/ConsortiumManager/settings/circulation/index.js
+++ b/src/routes/ConsortiumManager/settings/circulation/index.js
@@ -1,0 +1,1 @@
+export { default } from './CirculationSettings';

--- a/src/routes/ConsortiumManager/settings/data-export/DataExportSettings.js
+++ b/src/routes/ConsortiumManager/settings/data-export/DataExportSettings.js
@@ -1,0 +1,20 @@
+import { FormattedMessage } from 'react-intl';
+
+import { stripesShape } from '@folio/stripes/core';
+import { Settings } from '@folio/stripes/smart-components';
+
+const DataExportSettings = (props) => {
+  return (
+    <Settings
+      {...props}
+      sections={[]}
+      paneTitle={<FormattedMessage id="ui-data-export.settings.index.paneTitle" />}
+    />
+  );
+};
+
+DataExportSettings.propTypes = {
+  stripes: stripesShape.isRequired,
+};
+
+export default DataExportSettings;

--- a/src/routes/ConsortiumManager/settings/data-export/index.js
+++ b/src/routes/ConsortiumManager/settings/data-export/index.js
@@ -1,0 +1,1 @@
+export { default } from './DataExportSettings';

--- a/src/routes/ConsortiumManager/settings/data-import/DataImportSettings.js
+++ b/src/routes/ConsortiumManager/settings/data-import/DataImportSettings.js
@@ -1,0 +1,20 @@
+import { FormattedMessage } from 'react-intl';
+
+import { stripesShape } from '@folio/stripes/core';
+import { Settings } from '@folio/stripes/smart-components';
+
+const DataImportSettings = (props) => {
+  return (
+    <Settings
+      {...props}
+      sections={[]}
+      paneTitle={<FormattedMessage id="ui-data-import.settings.index.paneTitle" />}
+    />
+  );
+};
+
+DataImportSettings.propTypes = {
+  stripes: stripesShape.isRequired,
+};
+
+export default DataImportSettings;

--- a/src/routes/ConsortiumManager/settings/data-import/index.js
+++ b/src/routes/ConsortiumManager/settings/data-import/index.js
@@ -1,0 +1,1 @@
+export { default } from './DataImportSettings';

--- a/src/routes/ConsortiumManager/settings/inventory/InventorySettings.js
+++ b/src/routes/ConsortiumManager/settings/inventory/InventorySettings.js
@@ -1,0 +1,20 @@
+import { FormattedMessage } from 'react-intl';
+
+import { stripesShape } from '@folio/stripes/core';
+import { Settings } from '@folio/stripes/smart-components';
+
+const InventorySettings = (props) => {
+  return (
+    <Settings
+      {...props}
+      sections={[]}
+      paneTitle={<FormattedMessage id="ui-inventory.inventory.label" />}
+    />
+  );
+};
+
+InventorySettings.propTypes = {
+  stripes: stripesShape.isRequired,
+};
+
+export default InventorySettings;

--- a/src/routes/ConsortiumManager/settings/inventory/index.js
+++ b/src/routes/ConsortiumManager/settings/inventory/index.js
@@ -1,0 +1,1 @@
+export { default } from './InventorySettings';

--- a/src/routes/ConsortiumManager/settings/users/UsersSettings.js
+++ b/src/routes/ConsortiumManager/settings/users/UsersSettings.js
@@ -1,0 +1,20 @@
+import { FormattedMessage } from 'react-intl';
+
+import { stripesShape } from '@folio/stripes/core';
+import { Settings } from '@folio/stripes/smart-components';
+
+const UsersSettings = (props) => {
+  return (
+    <Settings
+      {...props}
+      sections={[]}
+      paneTitle={<FormattedMessage id="ui-users.settings.label" />}
+    />
+  );
+};
+
+UsersSettings.propTypes = {
+  stripes: stripesShape.isRequired,
+};
+
+export default UsersSettings;

--- a/src/routes/ConsortiumManager/settings/users/index.js
+++ b/src/routes/ConsortiumManager/settings/users/index.js
@@ -1,0 +1,1 @@
+export { default } from './UsersSettings';

--- a/src/utils/getModuleName.js
+++ b/src/utils/getModuleName.js
@@ -1,0 +1,5 @@
+import { PACKAGE_SCOPE_REGEX } from '../constants';
+
+export const getModuleName = ({ module } = {}) => {
+  return module?.replace(PACKAGE_SCOPE_REGEX, '');
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
 export { checkConsortiumAffiliations } from './checkConsortiumAffiliations';
 export { getCurrentModulePath } from './getCurrentModulePath';
 export { getLegacyTokenHeader } from './getLegacyTokenHeader';
+export { getModuleName } from './getModuleName';


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UICONSET-26

Allow authorized consortium staff to manage settings for one or more member libraries from within Consortium manager.
This should follow the same styles and methodologies used in the Settings app, but should not contain all available settings. Specific settings to be included will be outlined elsewhere.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- split consortium manager header into a separate component;
- define an initial list of settings to display in the consortium manager;
- add base components for each available setting;
- use `React.lazy` to defer initial loading of settings components’ code;
- add unit tests.

Note: module loading is artificially delayed locally for demonstration purposes
![chrome_zvLVJlUoWR](https://github.com/folio-org/ui-consortia-settings/assets/88109087/f75fd3d7-3be4-45c7-958f-7e421eaff7fb)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
