### PR TITLE
UICONSET-128 Move view/assign affiliation permissions from `ui-users` to `ui-consortia-settings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 * [UICONSET-123](https://issues.folio.org/browse/UICONSET-123) View list of import jobs.
 * [UICONSET-124](https://issues.folio.org/browse/UICONSET-124) View list of Export jobs.
 * [UICONSET-58](https://issues.folio.org/browse/UICONSET-58) View list of permissions set.
+* [UICONSET-128](https://issues.folio.org/browse/UICONSET-128) Move view/assign affiliation permissions from `ui-users` to `ui-consortia-settings`.

--- a/package.json
+++ b/package.json
@@ -144,6 +144,28 @@
         "visible": true
       },
       {
+        "permissionName": "ui-consortia-settings.consortia.affiliations.view",
+        "displayName": "Consortia: View affiliations",
+        "description": "View a list of affiliations assigned to an user",
+        "subPermissions": [
+          "consortia.consortium.collection.get",
+          "consortia.user-tenants.collection.get"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-consortia-settings.consortia.affiliations.edit",
+        "displayName": "Consortia: Assign and unassign affiliations",
+        "description": "Assign and unassign affiliations",
+        "subPermissions": [
+          "ui-consortia-settings.consortia.affiliations.view",
+          "consortia.tenants.collection.get",
+          "consortia.user-tenants.item.post",
+          "consortia.user-tenants.item.delete"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-consortia-settings.settings.membership.view",
         "displayName": "Settings (Consortia): Can view consortia membership",
         "subPermissions": [

--- a/translations/ui-consortia-settings/en.json
+++ b/translations/ui-consortia-settings/en.json
@@ -45,6 +45,8 @@
   "switchActiveAffiliation.modal.heading": "Select affiliation",
   "switchActiveAffiliation.modal.select.label": "Consortium members",
 
+  "permission.consortia.affiliations.view": "Consortia: View affiliations",
+  "permission.consortia.affiliations.edit": "Consortia: Assign and unassign affiliations",
   "permission.consortium-manager.view": "Consortium manager: Can view existing settings",
   "permission.consortium-manager.edit": "Consortium manager: Can create, edit and remove settings",
   "permission.consortium-manager.share": "Consortium manager: Can share settings to all members",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UICONSET-128

"View" and "Assign" affiliations permissions should be stored in ui-consortia-settings and available to assign only in the central tenant of a consortium.

Refs https://github.com/folio-org/ui-users/pull/2497

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
