### PR TITLE
UICONSET-113 Allow a user to share settings in the `<ConsortiaControlledVocabulary>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 * [UICONSET-127](https://issues.folio.org/browse/UICONSET-127) Implement `<ConsortiaControlledVolabulary>` component for consortium manager.
 * [UICONSET-59](https://issues.folio.org/browse/UICONSET-59) Consortia manager - Save/edit permissions set and assign users.
 * [UICONSET-111](https://issues.folio.org/browse/UICONSET-111) Apply publish coordinator to consortium member setting requests (without shared settings).
+* [UICONSET-113](https://issues.folio.org/browse/UICONSET-113) Allow a user to share settings in the `<ConsortiaControlledVocabulary>`.

--- a/package.json
+++ b/package.json
@@ -144,7 +144,8 @@
         "permissionName": "ui-consortia-settings.consortium-manager.share",
         "displayName": "Consortium manager: Can share settings to all members",
         "subPermissions": [
-          "ui-consortia-settings.consortium-manager.view"
+          "ui-consortia-settings.consortium-manager.view",
+          "consortia.sharing-settings.item.post"
         ],
         "visible": true
       },

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -212,13 +212,14 @@ export const ConsortiaControlledVocabulary = ({
   }, [allMembersLabel, primaryField, selectedMembers, showCallout, translations]);
 
   const onShare = useCallback((entry) => {
-    // TODO: show modal
-    // return upsertSharedSetting({ entry });
+    const entryToShare = entries.find(_entry => _entry[uniqueField] === entry[uniqueField]);
+
+    if (entryToShare?.shared) return upsertSharedSetting({ entry });
 
     return buildDialog({ type: DIALOG_TYPES.confirmShare }, { term: entry[primaryField] })
       .then(() => upsertSharedSetting({ entry }))
       .catch(safeReject);
-  }, [buildDialog, primaryField, upsertSharedSetting]);
+  }, [buildDialog, entries, primaryField, uniqueField, upsertSharedSetting]);
 
   const onCreate = useCallback(async ({ shared, ...entry }) => {
     const createPromise = shared

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -58,6 +58,8 @@ const skipAborted = (error) => {
 };
 
 const CREATE_BUTTON_LABEL = <FormattedMessage id="stripes-core.button.new" />;
+// Used in a translation to indicate a plural value.
+const SHARED_MEMBERS_COUNT = Number.MAX_SAFE_INTEGER;
 
 const EditableListMemoized = memo(EditableList);
 
@@ -205,7 +207,7 @@ export const ConsortiaControlledVocabulary = ({
     return showCallout({
       messageId: translations[translationKey] || `ui-consortia-settings.consortiumManager.controlledVocab.common.${translationKey}`,
       values: {
-        count: members.length,
+        count: entry.shared ? SHARED_MEMBERS_COUNT : members.length,
         members: members.join(', '),
         term: entry[primaryField],
       },
@@ -223,7 +225,8 @@ export const ConsortiaControlledVocabulary = ({
       .catch(safeReject);
   }, [buildDialog, entries, primaryField, uniqueField, upsertSharedSetting]);
 
-  const onCreate = useCallback(async ({ shared, ...entry }) => {
+  const onCreate = useCallback(async (hydratedEntry) => {
+    const { shared, ...entry } = hydratedEntry;
     const createPromise = shared
       ? onShare(entry)
       : createEntry({
@@ -234,14 +237,15 @@ export const ConsortiaControlledVocabulary = ({
     return createPromise.then(() => {
       showSuccessCallout({
         actionType: ACTION_TYPES.create,
-        entry,
+        entry: hydratedEntry,
       });
     })
       .then(refetch)
       .catch(skipAborted);
   }, [onShare, createEntry, selectedMembers, refetch, showSuccessCallout]);
 
-  const onUpdate = useCallback(async ({ shared, ...entry }) => {
+  const onUpdate = useCallback(async (hydratedEntry) => {
+    const { shared, ...entry } = hydratedEntry;
     const updatePromise = shared
       ? onShare(entry)
       : updateEntry({ entry });
@@ -249,14 +253,15 @@ export const ConsortiaControlledVocabulary = ({
     return updatePromise.then(() => {
       showSuccessCallout({
         actionType: ACTION_TYPES.update,
-        entry,
+        entry: hydratedEntry,
       });
     })
       .then(refetch)
       .catch(skipAborted);
   }, [onShare, refetch, showSuccessCallout, updateEntry]);
 
-  const handleDeleteEntry = useCallback(({ shared, ...entry }) => {
+  const handleDeleteEntry = useCallback((hydratedEntry) => {
+    const { shared, ...entry } = hydratedEntry;
     const deletePromise = shared
       ? deleteSharedSetting({ entry })
       : deleteEntry({ entry });

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import {
   noop,
+  omit,
   uniq,
   uniqueId,
 } from 'lodash';
@@ -211,7 +212,8 @@ export const ConsortiaControlledVocabulary = ({
     });
   }, [allMembersLabel, primaryField, selectedMembers, showCallout, translations]);
 
-  const onShare = useCallback((entry) => {
+  const onShare = useCallback((entryToShare) => {
+    const entry = omit(entryToShare, 'tenantId');
     const initEntryValue = entries.find(_entry => _entry[uniqueField] === entry[uniqueField]);
 
     if (initEntryValue?.shared) return upsertSharedSetting({ entry });

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -212,9 +212,9 @@ export const ConsortiaControlledVocabulary = ({
   }, [allMembersLabel, primaryField, selectedMembers, showCallout, translations]);
 
   const onShare = useCallback((entry) => {
-    const entryToShare = entries.find(_entry => _entry[uniqueField] === entry[uniqueField]);
+    const initEntryValue = entries.find(_entry => _entry[uniqueField] === entry[uniqueField]);
 
-    if (entryToShare?.shared) return upsertSharedSetting({ entry });
+    if (initEntryValue?.shared) return upsertSharedSetting({ entry });
 
     return buildDialog({ type: DIALOG_TYPES.confirmShare }, { term: entry[primaryField] })
       .then(() => upsertSharedSetting({ entry }))

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -142,7 +142,7 @@ export const ConsortiaControlledVocabulary = ({
     if (Array.isArray(items)) {
       const errors = items.reduce((acc, item, index) => {
         const itemErrors = Object.fromEntries(
-          Object.entries(validate(item, index, items) || {}).filter(([, value]) => Boolean(value)),
+          Object.entries(validate(item, index, items, entries) || {}).filter(([, value]) => Boolean(value)),
         );
 
         // Check if the primary field has had data entered into it.
@@ -164,7 +164,7 @@ export const ConsortiaControlledVocabulary = ({
     }
 
     return {};
-  }, [primaryField, validate]);
+  }, [entries, primaryField, validate]);
 
   const buildDialog = useCallback(({ type }, properties = {}) => {
     return new Promise((resolve, reject) => {

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -211,9 +211,18 @@ export const ConsortiaControlledVocabulary = ({
     });
   }, [allMembersLabel, primaryField, selectedMembers, showCallout, translations]);
 
+  const onShare = useCallback((entry) => {
+    // TODO: show modal
+    // return upsertSharedSetting({ entry });
+
+    return buildDialog({ type: DIALOG_TYPES.confirmShare })
+      .then(() => upsertSharedSetting({ entry }))
+      .catch(safeReject);
+  }, [buildDialog, upsertSharedSetting]);
+
   const onCreate = useCallback(async ({ shared, ...entry }) => {
     const createPromise = shared
-      ? upsertSharedSetting({ entry })
+      ? onShare(entry)
       : createEntry({
         entry,
         tenants: selectedMembers.map(({ id: _id }) => _id),
@@ -227,11 +236,11 @@ export const ConsortiaControlledVocabulary = ({
     })
       .then(refetch)
       .catch(skipAborted);
-  }, [createEntry, upsertSharedSetting, refetch, selectedMembers, showSuccessCallout]);
+  }, [onShare, createEntry, selectedMembers, refetch, showSuccessCallout]);
 
   const onUpdate = useCallback(async ({ shared, ...entry }) => {
     const updatePromise = shared
-      ? upsertSharedSetting({ entry })
+      ? onShare(entry)
       : updateEntry({ entry });
 
     return updatePromise.then(() => {
@@ -242,7 +251,7 @@ export const ConsortiaControlledVocabulary = ({
     })
       .then(refetch)
       .catch(skipAborted);
-  }, [refetch, showSuccessCallout, updateEntry, upsertSharedSetting]);
+  }, [onShare, refetch, showSuccessCallout, updateEntry]);
 
   const handleDeleteEntry = useCallback(({ shared, ...entry }) => {
     const deletePromise = shared

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -215,10 +215,10 @@ export const ConsortiaControlledVocabulary = ({
     // TODO: show modal
     // return upsertSharedSetting({ entry });
 
-    return buildDialog({ type: DIALOG_TYPES.confirmShare })
+    return buildDialog({ type: DIALOG_TYPES.confirmShare }, { term: entry[primaryField] })
       .then(() => upsertSharedSetting({ entry }))
       .catch(safeReject);
-  }, [buildDialog, upsertSharedSetting]);
+  }, [buildDialog, primaryField, upsertSharedSetting]);
 
   const onCreate = useCallback(async ({ shared, ...entry }) => {
     const createPromise = shared

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.test.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.test.js
@@ -69,7 +69,7 @@ const renderConsortiaControlledVocabulary = (props = {}) => render(
   { wrapper: ConsortiaControlledVocabularyWrapper },
 );
 
-wrapConsortiaControlledVocabularyDescribe({ entries: response[records] })('ConsortiaControlledVocabulary', ({ mutations }) => {
+wrapConsortiaControlledVocabularyDescribe({ entries: response[records] })('ConsortiaControlledVocabulary', ({ mutations, sharing }) => {
   it('should render consortia-related controlled vocabulary', () => {
     renderConsortiaControlledVocabulary();
 
@@ -129,6 +129,45 @@ wrapConsortiaControlledVocabularyDescribe({ entries: response[records] })('Conso
       await waitForElementToBeRemoved(confirmDeleteBtn);
 
       expect(mutations.deleteEntry).toHaveBeenCalledWith({ entry: response[records][0] });
+    });
+  });
+
+  describe('Sharing', () => {
+    it('should handle new record sharing', async () => {
+      renderConsortiaControlledVocabulary();
+
+      userEvent.click(await screen.findByText('stripes-core.button.new'));
+      userEvent.type(await screen.findByPlaceholderText('foo'), 'New');
+      userEvent.type(await screen.findByPlaceholderText('bar'), 'Record');
+      userEvent.click(await screen.findByText('ui-consortia-settings.share'));
+      userEvent.click(await screen.findByText('stripes-core.button.save'));
+
+      const confirmBtn = await screen.findByText('ui-consortia-settings.button.confirm');
+
+      userEvent.click(confirmBtn);
+      await waitForElementToBeRemoved(confirmBtn);
+
+      expect(sharing.upsertSharedSetting).toHaveBeenCalledWith({
+        entry: {
+          foo: 'New',
+          bar: 'Record',
+        },
+      });
+    });
+
+    it('should handle existing record sharing', async () => {
+      renderConsortiaControlledVocabulary();
+
+      userEvent.click(screen.getAllByLabelText('stripes-components.editThisItem')[0]);
+      userEvent.click(await screen.findByText('ui-consortia-settings.share'));
+      userEvent.click(await screen.findByText('stripes-core.button.save'));
+
+      const confirmBtn = await screen.findByText('ui-consortia-settings.button.confirm');
+
+      userEvent.click(confirmBtn);
+      await waitForElementToBeRemoved(confirmBtn);
+
+      expect(sharing.upsertSharedSetting).toHaveBeenCalledWith({ entry: response[records][0] });
     });
   });
 

--- a/src/components/ConsortiaControlledVocabulary/FieldSharedEntry.js
+++ b/src/components/ConsortiaControlledVocabulary/FieldSharedEntry.js
@@ -6,14 +6,15 @@ import { Field, useFormState } from 'react-final-form';
 import { useStripes } from '@folio/stripes/core';
 import { Checkbox } from '@folio/stripes/components';
 
+import { RECORD_SOURCE } from '../../constants';
+
 export const FieldSharedEntry = ({ fieldProps, field, rowIndex }) => {
   const stripes = useStripes();
   const { values } = useFormState();
   const entryValues = get(values, [field, rowIndex]);
 
   const isEditing = Boolean(entryValues?.id);
-  // TODO: check if the entry is a shared setting
-  const isShared = true;
+  const isShared = entryValues.source === RECORD_SOURCE.CONSORTIUM;
   const isDisabled = (isEditing && isShared) || !stripes.hasPerm('ui-consortia-settings.consortium-manager.share');
 
   return (

--- a/src/components/ConsortiaControlledVocabulary/FieldSharedEntry.js
+++ b/src/components/ConsortiaControlledVocabulary/FieldSharedEntry.js
@@ -6,7 +6,7 @@ import { Field, useFormState } from 'react-final-form';
 import { useStripes } from '@folio/stripes/core';
 import { Checkbox } from '@folio/stripes/components';
 
-import { RECORD_SOURCE } from '../../constants';
+import { isSettingShared } from '../../utils';
 
 export const FieldSharedEntry = ({ fieldProps, field, rowIndex }) => {
   const stripes = useStripes();
@@ -14,7 +14,7 @@ export const FieldSharedEntry = ({ fieldProps, field, rowIndex }) => {
   const entryValues = get(values, [field, rowIndex]);
 
   const isEditing = Boolean(entryValues?.id);
-  const isShared = entryValues.source === RECORD_SOURCE.CONSORTIUM;
+  const isShared = isSettingShared(entryValues);
   const isDisabled = (isEditing && isShared) || !stripes.hasPerm('ui-consortia-settings.consortium-manager.share');
 
   return (

--- a/src/components/ConsortiaControlledVocabulary/constants.js
+++ b/src/components/ConsortiaControlledVocabulary/constants.js
@@ -1,5 +1,6 @@
 import {
   ConfirmDeleteEntryModal,
+  ConfirmShareEntryModal,
   ItemInUseModal,
 } from './modals';
 
@@ -19,6 +20,7 @@ export const PANESET_PREFIX = 'consortia-controlled-vocabulary-paneset-';
 
 export const DIALOG_TYPES = {
   confirmDelete: 'confirmDelete',
+  confirmShare: 'confirmShare',
   itemInUse: 'itemInUse',
 };
 
@@ -39,6 +41,15 @@ export const DIALOGS_MAP = {
       open
       translations={translations}
       onConfirm={resolve}
+    />
+  ),
+  // eslint-disable-next-line react/prop-types
+  [DIALOG_TYPES.confirmShare]: ({ resolve, reject, term }) => (
+    <ConfirmShareEntryModal
+      open
+      term={term}
+      onConfirm={resolve}
+      onCancel={reject}
     />
   ),
 };

--- a/src/components/ConsortiaControlledVocabulary/modals/ConfirmShareEntryModal.js
+++ b/src/components/ConsortiaControlledVocabulary/modals/ConfirmShareEntryModal.js
@@ -11,7 +11,7 @@ export const ConfirmShareEntryModal = ({
 }) => {
   return (
     <ConfirmationModal
-      id="delete-controlled-vocab-entry-confirmation"
+      id="share-controlled-vocab-entry-confirmation"
       open={open}
       heading={<FormattedMessage id="ui-consortia-settings.consortiumManager.modal.confirmShare.all.heading" />}
       message={(
@@ -26,4 +26,11 @@ export const ConfirmShareEntryModal = ({
       confirmLabel={<FormattedMessage id="ui-consortia-settings.confirm" />}
     />
   );
+};
+
+ConfirmShareEntryModal.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  open: PropTypes.bool,
+  term: PropTypes.string.isRequired,
 };

--- a/src/components/ConsortiaControlledVocabulary/modals/ConfirmShareEntryModal.js
+++ b/src/components/ConsortiaControlledVocabulary/modals/ConfirmShareEntryModal.js
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { ConfirmationModal } from '@folio/stripes/components';
+
+export const ConfirmShareEntryModal = ({
+  open,
+  onConfirm,
+  onCancel,
+  term,
+}) => {
+  return (
+    <ConfirmationModal
+      id="delete-controlled-vocab-entry-confirmation"
+      open={open}
+      heading={<FormattedMessage id="ui-consortia-settings.consortiumManager.modal.confirmShare.all.heading" />}
+      message={(
+        <FormattedMessage
+          id="ui-consortia-settings.consortiumManager.modal.confirmShare.all.message"
+          values={{ term }}
+        />
+      )}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      cancelLabel={<FormattedMessage id="stripes-form.keepEditing" />}
+      confirmLabel={<FormattedMessage id="ui-consortia-settings.confirm" />}
+    />
+  );
+};

--- a/src/components/ConsortiaControlledVocabulary/modals/ConfirmShareEntryModal.js
+++ b/src/components/ConsortiaControlledVocabulary/modals/ConfirmShareEntryModal.js
@@ -23,7 +23,7 @@ export const ConfirmShareEntryModal = ({
       onConfirm={onConfirm}
       onCancel={onCancel}
       cancelLabel={<FormattedMessage id="stripes-form.keepEditing" />}
-      confirmLabel={<FormattedMessage id="ui-consortia-settings.confirm" />}
+      confirmLabel={<FormattedMessage id="ui-consortia-settings.button.confirm" />}
     />
   );
 };

--- a/src/components/ConsortiaControlledVocabulary/modals/index.js
+++ b/src/components/ConsortiaControlledVocabulary/modals/index.js
@@ -1,2 +1,3 @@
 export { ConfirmDeleteEntryModal } from './ConfirmDeleteEntryModal';
+export { ConfirmShareEntryModal } from './ConfirmShareEntryModal';
 export { ItemInUseModal } from './ItemInUseModal';

--- a/src/components/ConsortiaControlledVocabulary/validators/validateUniqueness.js
+++ b/src/components/ConsortiaControlledVocabulary/validators/validateUniqueness.js
@@ -1,7 +1,7 @@
 import { FormattedMessage } from 'react-intl';
 
 const isInitiallyShared = (item, initialValues) => Boolean(
-  initialValues.find(({ id, tenantId }) => id === item.id && tenantId === item.tenantId)?.shared
+  initialValues.find(({ id, tenantId }) => id === item.id && tenantId === item.tenantId)?.shared,
 );
 
 export const validateUniqueness = ({

--- a/src/components/ConsortiaControlledVocabulary/validators/validateUniqueness.js
+++ b/src/components/ConsortiaControlledVocabulary/validators/validateUniqueness.js
@@ -1,18 +1,34 @@
 import { FormattedMessage } from 'react-intl';
 
+const isInitiallyShared = (item, initialValues) => Boolean(
+  initialValues.find(({ id, tenantId }) => id === item.id && tenantId === item.tenantId)?.shared
+);
+
 export const validateUniqueness = ({
   index,
   item,
   items,
   field,
   message,
-}) => (
-  items.some((entry, i) => (item[field]?.toLocaleLowerCase() === entry[field]?.toLocaleLowerCase() && i !== index))
-    ? message || (
-      <FormattedMessage
-        id="stripes-smart-components.error.name.duplicate"
-        values={{ fieldLabel: field }}
-      />
-    )
-    : undefined
-);
+  initialValues = [],
+}) => {
+  return (
+    items.some((entry, i) => (
+      i !== index
+      && item[field]?.toLocaleLowerCase() === entry[field]?.toLocaleLowerCase()
+      && (
+        // If an existing entry is not initially shared, it must be unique within the tenant in which it exists.
+        !item.id
+        || (item.id && !item.shared && item.tenantId === entry.tenantId)
+        || (item.id && item.shared && isInitiallyShared(item, initialValues))
+      )
+    ))
+      ? message || (
+        <FormattedMessage
+          id="stripes-smart-components.error.name.duplicate"
+          values={{ fieldLabel: field }}
+        />
+      )
+      : undefined
+  );
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -78,3 +78,11 @@ export const RECORD_SOURCE = {
   RDA_MODE_ISSUE: 'rdamodeissue',
   UC: 'UC',
 };
+
+export const HTTP_METHODS = {
+  GET: 'GET',
+  POST: 'POST',
+  PUT: 'PUT',
+  PATCH: 'PATCH',
+  DELETE: 'DELETE',
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,7 @@ export const NATURE_OF_CONTENT_TERMS_API = 'nature-of-content-terms';
 export const PATRON_GROUPS_API = 'groups';
 export const PERMISSION_USERS_API = 'perms/users';
 export const PUBLICATIONS_API = 'publications';
+export const SETTINGS_SHARING_API = 'sharing/settings';
 export const STATISTICAL_CODE_TYPES_API = 'statistical-code-types';
 export const STATISTICAL_CODES_API = 'statistical-codes';
 /*  */

--- a/src/hooks/consortiumManager/index.js
+++ b/src/hooks/consortiumManager/index.js
@@ -1,2 +1,3 @@
 export { useSettings } from './useSettings';
 export { useSettingMutation } from './useSettingMutation';
+export { useSettingSharing } from './useSettingSharing';

--- a/src/hooks/consortiumManager/useSettingMutation.js
+++ b/src/hooks/consortiumManager/useSettingMutation.js
@@ -27,18 +27,11 @@ export const useSettingMutation = ({ path }) => {
     mutateAsync: createEntry,
   } = useMutation({
     mutationFn: ({ entry, tenants }) => {
-      const { shared, ...json } = entry;
-
-      if (shared) {
-        // TODO: implement creation of a shared setting
-        return Promise.reject(new Error('Not implemented yet'));
-      }
-
       const publication = {
         url: path,
         method: 'POST',
         tenants,
-        payload: { id: uuidv4(), ...json },
+        payload: { id: uuidv4(), ...entry },
       };
 
       return initPublicationRequest(publication).catch(throwErrorResponse);
@@ -50,12 +43,7 @@ export const useSettingMutation = ({ path }) => {
     mutateAsync: updateEntry,
   } = useMutation({
     mutationFn: ({ entry }) => {
-      const { shared, tenantId, ...json } = entry;
-
-      if (shared) {
-        // TODO: implement editing of a shared setting
-        return Promise.reject(new Error('Not implemented yet'));
-      }
+      const { tenantId, ...json } = entry;
 
       return injectTenantHeader(ky, tenantId).put(`${path}/${entry.id}`, { json }).catch(throwErrorResponse);
     },
@@ -66,14 +54,9 @@ export const useSettingMutation = ({ path }) => {
     mutateAsync: deleteEntry,
   } = useMutation({
     mutationFn: ({ entry }) => {
-      const { shared, tenantId } = entry;
+      const { id, tenantId } = entry;
 
-      if (shared) {
-        // TODO: implement deletion of a shared setting
-        return Promise.reject(new Error('Not implemented yet'));
-      }
-
-      return injectTenantHeader(ky, tenantId).delete(`${path}/${entry.id}`).catch(throwErrorResponse);
+      return injectTenantHeader(ky, tenantId).delete(`${path}/${id}`).catch(throwErrorResponse);
     },
   });
 

--- a/src/hooks/consortiumManager/useSettingMutation.test.js
+++ b/src/hooks/consortiumManager/useSettingMutation.test.js
@@ -25,7 +25,7 @@ const wrapper = ({ children }) => (
 
 const path = 'some-storage/entries';
 const setting = { id: 'test-id', name: 'foo' };
-const localHydratedSetting = { ...setting, shared: false, tenantId: 'tenantId' };
+const localHydratedSetting = { ...setting, tenantId: 'tenantId' };
 
 const kyMock = {
   extend: jest.fn(() => kyMock),

--- a/src/hooks/consortiumManager/useSettingSharing.js
+++ b/src/hooks/consortiumManager/useSettingSharing.js
@@ -9,10 +9,12 @@ import {
 
 import {
   CONSORTIA_API,
-  RECORD_SOURCE,
   SETTINGS_SHARING_API,
 } from '../../constants';
-import { throwErrorResponse } from '../../utils';
+import {
+  isSettingShared,
+  throwErrorResponse,
+} from '../../utils';
 import { usePublishCoordinator } from '../usePublishCoordinator';
 
 export const useSettingSharing = ({ path }, options = {}) => {
@@ -61,7 +63,7 @@ export const useSettingSharing = ({ path }, options = {}) => {
           id: settingId,
         },
       };
-      const isShared = entry.source === RECORD_SOURCE.CONSORTIUM;
+      const isShared = isSettingShared(entry);
 
       return initSettingSharingRequest(
         publication,

--- a/src/hooks/consortiumManager/useSettingSharing.js
+++ b/src/hooks/consortiumManager/useSettingSharing.js
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from 'react';
+import { useMutation } from 'react-query';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+
+import {
+  CONSORTIA_API,
+  RECORD_SOURCE,
+  SETTINGS_SHARING_API,
+} from '../../constants';
+import { throwErrorResponse } from '../../utils';
+import { usePublishCoordinator } from '../usePublishCoordinator';
+
+export const useSettingSharing = ({ path }, options = {}) => {
+  const ky = useOkapiKy();
+  const stripes = useStripes();
+  const abortController = useRef(new AbortController());
+
+  const { getPublicationDetails } = usePublishCoordinator();
+
+  const consortium = stripes.user?.user?.consortium;
+  const baseApi = `${CONSORTIA_API}/${consortium?.id}/${SETTINGS_SHARING_API}`;
+
+  useEffect(() => {
+    return () => {
+      abortController.current.abort();
+    };
+  }, []);
+
+  const initSettingSharingRequest = ({ url, ...setting }, { method, publicationKey }) => {
+    abortController.current = new AbortController();
+    const signal = options.signal || abortController.current.signal;
+    const json = {
+      // Publications API requires `url` value to start with slash (`/`)
+      url: url.startsWith('/') ? url : `/${url}`,
+      ...setting,
+    };
+
+    const api = method === 'POST' ? baseApi : `${baseApi}/${setting.settingId}`;
+
+    return ky(api, { method, json, signal })
+      .json()
+      .then(res => getPublicationDetails(res[publicationKey], { signal }))
+      .catch(throwErrorResponse);
+  };
+
+  const {
+    mutateAsync: upsertSharedSetting,
+  } = useMutation({
+    mutationFn: ({ entry }) => {
+      const settingId = entry.id || uuidv4();
+      const publication = {
+        settingId,
+        url: path,
+        payload: {
+          ...entry,
+          id: settingId,
+        },
+      };
+      const isShared = entry.source === RECORD_SOURCE.CONSORTIUM;
+
+      return initSettingSharingRequest(
+        publication,
+        {
+          method: 'POST',
+          publicationKey: isShared ? 'updateSettingsPCId' : 'createSettingsPCId',
+        },
+      );
+    },
+  });
+
+  const {
+    mutateAsync: deleteSharedSetting,
+  } = useMutation({
+    mutationFn: ({ entry }) => {
+      const publication = {
+        settingId: entry.id,
+        url: `${path}/${entry.id}`,
+      };
+
+      // TODO: implement creation of a shared setting
+      return Promise.reject(new Error('Not implemented yet'));
+
+      // return initSettingSharingRequest(publication, { method: 'DELETE', publicationKey: 'pcId' });
+    },
+  });
+
+  return {
+    upsertSharedSetting,
+    deleteSharedSetting,
+  };
+};

--- a/src/hooks/consortiumManager/useSettingSharing.js
+++ b/src/hooks/consortiumManager/useSettingSharing.js
@@ -88,7 +88,7 @@ export const useSettingSharing = ({ path }, options = {}) => {
         url: `${path}/${entry.id}`,
       };
 
-      // TODO: implement creation of a shared setting
+      // TODO: implement deletion of a shared setting
       // return initSettingSharingRequest(request, { method: HTTP_METHODS.DELETE });
       return Promise.reject(new Error('Not implemented yet' + JSON.stringify(request)));
     },

--- a/src/hooks/consortiumManager/useSettingSharing.js
+++ b/src/hooks/consortiumManager/useSettingSharing.js
@@ -15,7 +15,7 @@ import {
 import { throwErrorResponse } from '../../utils';
 import { usePublishCoordinator } from '../usePublishCoordinator';
 
-const PC_SHARE_DETAILS_KEYS = {
+export const PC_SHARE_DETAILS_KEYS = {
   create: 'createSettingsPCId',
   update: 'updateSettingsPCId',
   // TODO: adjust with BE (MODCON-71)
@@ -62,6 +62,7 @@ export const useSettingSharing = ({ path }, options = {}) => {
   }, [baseApi, getPublicationDetails, ky, options.signal]);
 
   const {
+    isLoading: isUpserting,
     mutateAsync: upsertSharedSetting,
   } = useMutation({
     mutationFn: ({ entry }) => {
@@ -80,6 +81,7 @@ export const useSettingSharing = ({ path }, options = {}) => {
   });
 
   const {
+    isLoading: isDeleting,
     mutateAsync: deleteSharedSetting,
   } = useMutation({
     mutationFn: ({ entry }) => {
@@ -94,7 +96,10 @@ export const useSettingSharing = ({ path }, options = {}) => {
     },
   });
 
+  const isLoading = isUpserting || isDeleting;
+
   return {
+    isLoading,
     upsertSharedSetting,
     deleteSharedSetting,
   };

--- a/src/hooks/consortiumManager/useSettingSharing.test.js
+++ b/src/hooks/consortiumManager/useSettingSharing.test.js
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { pcPublicationResults } from 'fixtures';
+import { usePublishCoordinator } from '../usePublishCoordinator';
+import {
+  PC_SHARE_DETAILS_KEYS,
+  useSettingSharing,
+} from './useSettingSharing';
+import {
+  HTTP_METHODS,
+  SETTINGS_SHARING_API,
+} from '../../constants';
+
+jest.mock('../usePublishCoordinator', () => ({
+  usePublishCoordinator: jest.fn(),
+}));
+
+const queryClient = new QueryClient();
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+const path = '/some-storage/entries';
+const setting = { id: 'test-id', name: 'foo' };
+const pcId = 'test-pc-id';
+
+const getKyMock = (result) => jest.fn(() => ({
+  json: () => Promise.resolve(result),
+}));
+const getPublicationDetails = jest.fn(() => Promise.resolve(pcPublicationResults));
+
+describe('useSettingSharing', () => {
+  beforeEach(() => {
+    getPublicationDetails.mockClear();
+    useOkapiKy.mockClear();
+    usePublishCoordinator.mockClear().mockReturnValue(({ getPublicationDetails }));
+  });
+
+  describe('Upsert shared setting', () => {
+    it('should send POST request to sharing settings API to initiate PC request', async () => {
+      const kyMock = getKyMock({ [PC_SHARE_DETAILS_KEYS.create]: pcId });
+
+      useOkapiKy.mockReturnValue(kyMock);
+
+      const { result, waitFor } = renderHook(() => useSettingSharing({ path }), { wrapper });
+      const pcResults = await result.current.upsertSharedSetting({ entry: setting });
+
+      await waitFor(() => !result.current.isLoading);
+
+      expect(kyMock).toHaveBeenCalledWith(
+        expect.stringContaining(SETTINGS_SHARING_API),
+        expect.objectContaining({
+          method: HTTP_METHODS.POST,
+          json: expect.objectContaining({
+            settingId: setting.id,
+            url: path,
+            payload: expect.objectContaining(setting),
+          }),
+        }),
+      );
+      expect(getPublicationDetails).toHaveBeenCalledWith(pcId, expect.objectContaining({}));
+      expect(pcResults).toEqual(pcPublicationResults);
+    });
+  });
+});

--- a/src/hooks/usePublishCoordinator/usePublishCoordinator.test.js
+++ b/src/hooks/usePublishCoordinator/usePublishCoordinator.test.js
@@ -16,8 +16,6 @@ import { TIMEOUT, usePublishCoordinator } from './usePublishCoordinator';
 
 const queryClient = new QueryClient();
 
-const nativeResponse = global.Response;
-
 // eslint-disable-next-line react/prop-types
 const wrapper = ({ children }) => (
   <QueryClientProvider client={queryClient}>
@@ -56,14 +54,6 @@ describe('usePublishCoordinator.test', () => {
       json: () => Promise.resolve(pcPublicationDetails),
     }));
     useOkapiKy.mockClear().mockReturnValue(kyMock);
-  });
-
-  beforeAll(() => {
-    global.Response = global?.Response || class ResponseMock {};
-  });
-
-  afterAll(() => {
-    global.Response = nativeResponse;
   });
 
   it('should initiate publish coordinator request to get records from provided tenants', async () => {

--- a/src/routes/ConsortiumManager/settings/inventory/instances-holdings-items/StatisticalCodes/validate.js
+++ b/src/routes/ConsortiumManager/settings/inventory/instances-holdings-items/StatisticalCodes/validate.js
@@ -3,8 +3,8 @@ import {
   validateUniqueness,
 } from '../../../../../../components/ConsortiaControlledVocabulary/validators';
 
-export const validate = (item, index, items) => {
-  const validateFieldUniqueness = (field) => validateUniqueness({ index, item, items, field });
+export const validate = (item, index, items, initialValues) => {
+  const validateFieldUniqueness = (field) => validateUniqueness({ index, item, items, field, initialValues });
 
   const nameError = validateRequired({ value: item.name }) || validateFieldUniqueness('name');
   const codeError = validateRequired({ value: item.code }) || validateFieldUniqueness('code');

--- a/src/routes/ConsortiumManager/settings/users/general/Departments/validate.js
+++ b/src/routes/ConsortiumManager/settings/users/general/Departments/validate.js
@@ -5,13 +5,14 @@ import {
   validateUniqueness,
 } from '../../../../../../components/ConsortiaControlledVocabulary/validators';
 
-export const validate = (item, index, items) => {
+export const validate = (item, index, items, initialValues) => {
   const validateFieldUniqueness = (field, message) => validateUniqueness({
     index,
     item,
     items,
     field,
     message,
+    initialValues,
   });
 
   const nameError = validateFieldUniqueness('name', <FormattedMessage id="ui-users.settings.departments.name.error" />);

--- a/src/utils/hydrateSharedRecords.js
+++ b/src/utils/hydrateSharedRecords.js
@@ -25,7 +25,7 @@ export const hydrateSharedRecords = (
 
       return { ...item, ...additive };
     })
-  ));
+  )).filter(Boolean);
 
   return Object.entries(groupBy(flattenRecords, 'id')).flatMap(([recordId, items]) => {
     return sharedRecordIds.has(recordId)

--- a/src/utils/hydrateSharedRecords.js
+++ b/src/utils/hydrateSharedRecords.js
@@ -1,6 +1,6 @@
 import groupBy from 'lodash/groupBy';
 
-import { RECORD_SOURCE } from '../constants';
+import { isSettingShared } from './isSettingShared';
 
 const defaultSquashFn = (sharedSettingRecords) => {
   return sharedSettingRecords.reduce((acc, curr) => Object.assign(acc, curr), {});
@@ -14,7 +14,7 @@ export const hydrateSharedRecords = (
 
   const flattenRecords = publicationResults.flatMap(({ tenantId, response }) => (
     response[recordsField]?.map((item) => {
-      const shared = item.source === RECORD_SOURCE.CONSORTIUM;
+      const shared = isSettingShared(item);
 
       if (shared) sharedRecordIds.add(item.id);
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,4 +3,5 @@ export { getCurrentModulePath } from './getCurrentModulePath';
 export { getLegacyTokenHeader } from './getLegacyTokenHeader';
 export { getModuleName } from './getModuleName';
 export { hydrateSharedRecords } from './hydrateSharedRecords';
+export { isSettingShared } from './isSettingShared';
 export { throwErrorResponse } from './throwErrorResponse';

--- a/src/utils/isSettingShared.js
+++ b/src/utils/isSettingShared.js
@@ -1,0 +1,5 @@
+import { RECORD_SOURCE } from '../constants';
+
+export const isSettingShared = (setting) => {
+  return setting?.source === RECORD_SOURCE.CONSORTIUM;
+};

--- a/test/jest/helpers/wrapConsortiaControlledVocabularyDescribe.js
+++ b/test/jest/helpers/wrapConsortiaControlledVocabularyDescribe.js
@@ -5,6 +5,7 @@ import { useUsersBatch } from '@folio/stripes-acq-components';
 import {
   useSettings,
   useSettingMutation,
+  useSettingSharing,
 } from '../../../src/hooks/consortiumManager';
 
 jest.unmock('react-final-form-arrays');
@@ -15,6 +16,7 @@ jest.mock('@folio/stripes-acq-components', () => ({
 jest.mock('../../../src/hooks/consortiumManager', () => ({
   useSettings: jest.fn(),
   useSettingMutation: jest.fn(),
+  useSettingSharing: jest.fn(),
 }));
 
 export const wrapConsortiaControlledVocabularyDescribe = ({
@@ -37,6 +39,11 @@ export const wrapConsortiaControlledVocabularyDescribe = ({
     isLoading: false,
   };
 
+  const sharingMock = {
+    deleteSharedSetting: jest.fn(() => Promise.resolve()),
+    upsertSharedSetting: jest.fn(() => Promise.resolve()),
+  };
+
   const usersMock = {
     users: uniqBy(
       entries.filter(({ metadata }) => Boolean(metadata?.updatedByUserId)),
@@ -57,8 +64,11 @@ export const wrapConsortiaControlledVocabularyDescribe = ({
       mutationsMock.createEntry.mockClear();
       mutationsMock.updateEntry.mockClear();
       mutationsMock.deleteEntry.mockClear();
+      sharingMock.deleteSharedSetting.mockClear();
+      sharingMock.upsertSharedSetting.mockClear();
       useSettings.mockClear().mockReturnValue(entriesMock);
       useSettingMutation.mockClear().mockReturnValue(mutationsMock);
+      useSettingSharing.mockClear().mockReturnValue(sharingMock);
       useUsersBatch.mockClear().mockReturnValue(usersMock);
     });
 

--- a/test/jest/helpers/wrapConsortiaControlledVocabularyDescribe.js
+++ b/test/jest/helpers/wrapConsortiaControlledVocabularyDescribe.js
@@ -75,6 +75,7 @@ export const wrapConsortiaControlledVocabularyDescribe = ({
     callback({
       entries: entriesMock,
       mutations: mutationsMock,
+      sharing: sharingMock,
     });
   });
 };

--- a/translations/ui-consortia-settings/en.json
+++ b/translations/ui-consortia-settings/en.json
@@ -3,6 +3,7 @@
 
   "affiliation.primary.suffix": "(Primary)",
 
+  "button.confirm": "Confirm",
   "button.saveAndClose": "Save & close",
 
   "errors.jobs.load.common": "Could not load jobs data.",
@@ -143,6 +144,8 @@
   "consortiumManager.members.permissionSets.remove.permissionSet.success": "The permission set <strong>{permissionName}</strong> was successfully <strong>deleted</strong>.",
   "consortiumManager.members.permissionSets.save.permissionSet.success": "The permission set <strong>{permissionName}</strong> was successfully <strong>saved</strong>.",
 
+  "consortiumManager.modal.confirmShare.all.heading": "Confirm share to all",
+  "consortiumManager.modal.confirmShare.all.message": "Are you sure you want to share {term} with <b>ALL</b> members?",
 
   "settings.heading": "Network settings",
   "settings.section.general": "General",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UICONSET-113

Consortium administrators need to "share" certain consortium-wide system settings to all members of a consortium, and to maintain control over these settings.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Use sharing API (see "Learning") to initiate sharing setting process - a publish coordinator ID will be returned to handle results;
- Use publish coordinator to get sharing results - use the ID returned from the sharing setting API;
- Handle sharing setting on UI - display confirmation modal;
- Adjust `validateUniqueness` to consortia-related purposes - validate local settings in the specific tenant and not in the whole list;
- Add/update unit tests.
## Screencast
![chrome_TeY0Wb58w8](https://github.com/folio-org/ui-consortia-settings/assets/88109087/75548823-2572-4ab9-a45c-69319dc1cf4d)


## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
- Settings sharing API - https://s3.amazonaws.com/foliodocs/api/mod-consortia/s/sharing_settings.html
- Publish coordinator API - https://s3.amazonaws.com/foliodocs/api/mod-consortia/s/publications.html

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
