### PR TITLE
UICONSET-111 Use `_self` endpoint to get current user permissions in the different tenants

### DIFF
--- a/src/Root.test.js
+++ b/src/Root.test.js
@@ -8,8 +8,8 @@ import { useStripes } from '@folio/stripes/core';
 import { affiliations } from 'fixtures';
 import { MODULE_ROOT_ROUTE } from './constants';
 import {
+  useCurrentUserTenantsPermissions,
   useUserAffiliations,
-  useUserTenantsPermissions,
 } from './hooks';
 import Root from './Root';
 
@@ -19,8 +19,8 @@ jest.mock('@folio/stripes/core', () => ({
   updateUser: jest.fn(),
 }));
 jest.mock('./hooks', () => ({
+  useCurrentUserTenantsPermissions: jest.fn(),
   useUserAffiliations: jest.fn(),
-  useUserTenantsPermissions: jest.fn(),
 }));
 jest.mock('./settings', () => jest.fn(() => 'ConsortiumSettings'));
 jest.mock('./routes', () => ({
@@ -63,7 +63,7 @@ describe('Root', () => {
 
       return { affiliations };
     });
-    useUserTenantsPermissions.mockClear().mockReturnValue({ permissionNames: [] });
+    useCurrentUserTenantsPermissions.mockClear().mockReturnValue({ tenantsPermissions: {} });
   });
 
   afterAll(() => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ export const OKAPI_TOKEN_HEADER = 'X-Okapi-Token';
 
 /* APIs */
 export const ALTERNATIVE_TITLE_TYPES_API = 'alternative-title-types';
+export const BL_USERS_API = 'bl-users';
 export const CANCELLATION_REASONS_API = 'cancellation-reason-storage/cancellation-reasons';
 export const CLASSIFICATION_TYPES_API = 'classification-types';
 export const CONFIGURATIONS_API = 'configurations';

--- a/src/contexts/ConsortiumManagerContext.js
+++ b/src/contexts/ConsortiumManagerContext.js
@@ -13,8 +13,8 @@ import {
 } from '@folio/stripes/core';
 
 import {
+  useCurrentUserTenantsPermissions,
   useUserAffiliations,
-  useUserTenantsPermissions,
 } from '../hooks';
 
 const DEFAULT_SELECTED_MEMBERS = [];
@@ -50,13 +50,13 @@ export const ConsortiumManagerContextProvider = ({ children }) => {
   );
 
   const {
-    permissionNames,
+    tenantsPermissions,
     isFetching: isPermissionsFetching,
-  } = useUserTenantsPermissions({ userId, tenants: selectedMembers?.map(({ id }) => id) });
+  } = useCurrentUserTenantsPermissions({ tenants: selectedMembers?.map(({ id }) => id) });
 
   const isFetching = isPermissionsFetching || isAffiliationsFetching;
 
-  const permissionNamesMap = useMemo(() => Object.entries(permissionNames).reduce((acc, [tenant, perms]) => {
+  const permissionNamesMap = useMemo(() => Object.entries(tenantsPermissions).reduce((acc, [tenant, perms]) => {
     acc[tenant] = perms.reduce((_acc, perm) => {
       _acc[perm] = true;
 
@@ -64,7 +64,7 @@ export const ConsortiumManagerContextProvider = ({ children }) => {
     }, {});
 
     return acc;
-  }, {}), [permissionNames]);
+  }, {}), [tenantsPermissions]);
 
   const hasPerm = useCallback((tenantIds, permissions) => {
     const tenants = (Array.isArray(tenantIds) ? tenantIds : [tenantIds]).filter(Boolean);

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,6 +1,6 @@
 export { useCurrentConsortium } from './useCurrentConsortium';
+export { useCurrentUserTenantsPermissions } from './useCurrentUserTenantsPermissions';
 export { usePublishCoordinator } from './usePublishCoordinator';
 export { useTenantKy } from './useTenantKy';
 export { useTenantPermissions } from './useTenantPermissions';
 export { useUserAffiliations } from './useUserAffiliations';
-export { useUserTenantsPermissions } from './useUserTenantsPermissions';

--- a/src/hooks/useCurrentUserTenantsPermissions/index.js
+++ b/src/hooks/useCurrentUserTenantsPermissions/index.js
@@ -1,0 +1,1 @@
+export { useCurrentUserTenantsPermissions } from './useCurrentUserTenantsPermissions';

--- a/src/hooks/useCurrentUserTenantsPermissions/useCurrentUserTenantsPermissions.test.js
+++ b/src/hooks/useCurrentUserTenantsPermissions/useCurrentUserTenantsPermissions.test.js
@@ -50,7 +50,7 @@ describe('useCurrentUserTenantsPermissions', () => {
   });
 
   it('should send a publish coordinator request to get user permissions in the provided tenants', async () => {
-    const { result } = renderHook(() => useCurrentUserTenantsPermissions({ userId, tenants }), { wrapper });
+    const { result } = renderHook(() => useCurrentUserTenantsPermissions({ tenants }), { wrapper });
 
     await waitFor(() => expect(result.current.isFetching).toBeFalsy());
 

--- a/src/hooks/useCurrentUserTenantsPermissions/useCurrentUserTenantsPermissions.test.js
+++ b/src/hooks/useCurrentUserTenantsPermissions/useCurrentUserTenantsPermissions.test.js
@@ -9,7 +9,7 @@ import { tenants as tenantsMock } from 'fixtures';
 import { ConsortiumManagerContextProviderMock } from 'helpers';
 import { PERMISSION_USERS_API } from '../../constants';
 import { usePublishCoordinator } from '../usePublishCoordinator';
-import { useUserTenantsPermissions } from './useUserTenantsPermissions';
+import { useCurrentUserTenantsPermissions } from './useCurrentUserTenantsPermissions';
 
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
@@ -33,25 +33,25 @@ const wrapper = ({ children }) => (
 
 const userId = 'userId';
 const tenants = tenantsMock.slice(3).map(({ id }) => id);
-const permissionNames = ['post', 'put', 'delete'];
+const permissions = ['post', 'put', 'delete'];
 const response = {
   publicationResults: tenantsMock.map(({ id }) => ({
     tenantId: id,
-    response: { permissionNames },
+    response: { permissions },
     statusCode: 200,
   })),
 };
 
 const initPublicationRequest = jest.fn();
 
-describe('useUserTenantsPermissions', () => {
+describe('useCurrentUserTenantsPermissions', () => {
   beforeEach(() => {
     initPublicationRequest.mockClear().mockResolvedValue(response);
     usePublishCoordinator.mockClear().mockReturnValue(({ initPublicationRequest }));
   });
 
   it('should send a publish coordinator request to get user permissions in the provided tenants', async () => {
-    const { result } = renderHook(() => useUserTenantsPermissions({ userId, tenants }), { wrapper });
+    const { result } = renderHook(() => useCurrentUserTenantsPermissions({ userId, tenants }), { wrapper });
 
     await waitFor(() => expect(result.current.isFetching).toBeFalsy());
 
@@ -60,8 +60,8 @@ describe('useUserTenantsPermissions', () => {
       tenants,
       url: expect.stringContaining(`${PERMISSION_USERS_API}/${userId}/permissions`),
     });
-    expect(result.current.permissionNames).toEqual(expect.objectContaining(
-      tenants.reduce((acc, tenantId) => ({ ...acc, [tenantId]: permissionNames }), {}),
+    expect(result.current.tenantsPermissions).toEqual(expect.objectContaining(
+      tenants.reduce((acc, tenantId) => ({ ...acc, [tenantId]: permissions }), {}),
     ));
   });
 });

--- a/src/hooks/useCurrentUserTenantsPermissions/useCurrentUserTenantsPermissions.test.js
+++ b/src/hooks/useCurrentUserTenantsPermissions/useCurrentUserTenantsPermissions.test.js
@@ -7,7 +7,7 @@ import { renderHook, waitFor } from '@folio/jest-config-stripes/testing-library/
 
 import { tenants as tenantsMock } from 'fixtures';
 import { ConsortiumManagerContextProviderMock } from 'helpers';
-import { PERMISSION_USERS_API } from '../../constants';
+import { BL_USERS_API } from '../../constants';
 import { usePublishCoordinator } from '../usePublishCoordinator';
 import { useCurrentUserTenantsPermissions } from './useCurrentUserTenantsPermissions';
 
@@ -31,13 +31,12 @@ const wrapper = ({ children }) => (
   </QueryClientProvider>
 );
 
-const userId = 'userId';
 const tenants = tenantsMock.slice(3).map(({ id }) => id);
 const permissions = ['post', 'put', 'delete'];
 const response = {
   publicationResults: tenantsMock.map(({ id }) => ({
     tenantId: id,
-    response: { permissions },
+    response: { permissions: { permissions } },
     statusCode: 200,
   })),
 };
@@ -58,7 +57,7 @@ describe('useCurrentUserTenantsPermissions', () => {
     expect(initPublicationRequest).toHaveBeenCalledWith({
       method: 'GET',
       tenants,
-      url: expect.stringContaining(`${PERMISSION_USERS_API}/${userId}/permissions`),
+      url: expect.stringContaining(`${BL_USERS_API}/_self`),
     });
     expect(result.current.tenantsPermissions).toEqual(expect.objectContaining(
       tenants.reduce((acc, tenantId) => ({ ...acc, [tenantId]: permissions }), {}),

--- a/src/hooks/useUserTenantsPermissions/index.js
+++ b/src/hooks/useUserTenantsPermissions/index.js
@@ -1,1 +1,0 @@
-export { useUserTenantsPermissions } from './useUserTenantsPermissions';


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
Improving of https://github.com/folio-org/ui-consortia-settings/pull/54

The current implementation uses `users/perms/{id}/permissions` endpoint that is protected by special permissions. We need a way to allow the current user to get his permissions in affiliated members without assigning external permissions.

Required by [UICONSET-112](https://issues.folio.org/browse/UICONSET-112)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Use `bl-users/_self` endpoint in the publish coordinator to get the current user's permissions.
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
https://github.com/folio-org/ui-consortia-settings/assets/88109087/2d837ab7-a232-4ad5-82f8-4a61a046c385

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->


<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
