### PR TITLE
UICONSET-112 Implement the event emitter to handle events across components

### DIFF
--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -31,7 +31,10 @@ import {
   useUsersBatch,
 } from '@folio/stripes-acq-components';
 
-import { UNIQUE_FIELD_KEY } from '../../constants';
+import {
+  EVENT_EMITTER_EVENTS,
+  UNIQUE_FIELD_KEY,
+} from '../../constants';
 import { useConsortiumManagerContext } from '../../contexts';
 import {
   useSettings,
@@ -102,15 +105,17 @@ export const ConsortiaControlledVocabulary = ({
   const [activeDialog, setActiveDialog] = useState(null);
 
   const {
+    eventEmitterRef,
     hasPerm,
     permissionNamesMap,
     selectedMembers,
-    setSelectMembersDisabled,
     isFetching: isContextDataFetching,
   } = useConsortiumManagerContext();
 
   useEffect(() => {
-    setSelectMembersDisabled(false);
+    return () => {
+      eventEmitterRef.current.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false);
+    }
   }, []);
 
   const panesetId = `${PANESET_PREFIX}${id}`;
@@ -121,8 +126,8 @@ export const ConsortiaControlledVocabulary = ({
   const onStatusChange = useCallback((_prevStatus, currStatus) => {
     const isEditing = currStatus.some(({ editing }) => Boolean(editing));
 
-    setSelectMembersDisabled(isEditing);
-  }, [setSelectMembersDisabled]);
+    eventEmitterRef.current.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, isEditing);
+  }, []);
 
   const handleSettingsLoading = useCallback(({ errors }) => {
     if (errors?.length) {
@@ -339,7 +344,7 @@ export const ConsortiaControlledVocabulary = ({
       });
     })
       .then(refetch)
-      .finally(() => setSelectMembersDisabled(false))
+      .finally(() => eventEmitterRef.current.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false))
       .catch(skipAborted);
   }, [onShare, handleCreateEntry, refetch, showSuccessCallout]);
 
@@ -356,7 +361,7 @@ export const ConsortiaControlledVocabulary = ({
       });
     })
       .then(refetch)
-      .finally(() => setSelectMembersDisabled(false))
+      .finally(() => eventEmitterRef.current.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false))
       .catch(skipAborted);
   }, [onShare, refetch, showSuccessCallout, updateEntry]);
 

--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.js
@@ -36,6 +36,7 @@ import {
   UNIQUE_FIELD_KEY,
 } from '../../constants';
 import { useConsortiumManagerContext } from '../../contexts';
+import { useEventEmitter } from '../../hooks';
 import {
   useSettings,
   useSettingMutation,
@@ -102,10 +103,10 @@ export const ConsortiaControlledVocabulary = ({
   const paneTitleRef = useRef();
   const showCallout = useShowCallout();
   const stripes = useStripes();
+  const eventEmitter = useEventEmitter();
   const [activeDialog, setActiveDialog] = useState(null);
 
   const {
-    eventEmitterRef,
     hasPerm,
     permissionNamesMap,
     selectedMembers,
@@ -114,7 +115,7 @@ export const ConsortiaControlledVocabulary = ({
 
   useEffect(() => {
     return () => {
-      eventEmitterRef.current.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false);
+      eventEmitter.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false);
     }
   }, []);
 
@@ -126,7 +127,7 @@ export const ConsortiaControlledVocabulary = ({
   const onStatusChange = useCallback((_prevStatus, currStatus) => {
     const isEditing = currStatus.some(({ editing }) => Boolean(editing));
 
-    eventEmitterRef.current.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, isEditing);
+    eventEmitter.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, isEditing);
   }, []);
 
   const handleSettingsLoading = useCallback(({ errors }) => {
@@ -344,7 +345,7 @@ export const ConsortiaControlledVocabulary = ({
       });
     })
       .then(refetch)
-      .finally(() => eventEmitterRef.current.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false))
+      .finally(() => eventEmitter.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false))
       .catch(skipAborted);
   }, [onShare, handleCreateEntry, refetch, showSuccessCallout]);
 
@@ -361,7 +362,7 @@ export const ConsortiaControlledVocabulary = ({
       });
     })
       .then(refetch)
-      .finally(() => eventEmitterRef.current.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false))
+      .finally(() => eventEmitter.emit(EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS, false))
       .catch(skipAborted);
   }, [onShare, refetch, showSuccessCallout, updateEntry]);
 

--- a/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.js
+++ b/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.js
@@ -1,4 +1,9 @@
-import { useMemo, useRef } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -6,6 +11,7 @@ import {
   Paneset,
 } from '@folio/stripes/components';
 
+import { EVENT_EMITTER_EVENTS } from '../../constants';
 import { useConsortiumManagerContext } from '../../contexts';
 import { FindConsortiumMember } from '../FindConsortiumMember';
 
@@ -13,12 +19,24 @@ import css from './ConsortiumManagerHeader.css';
 
 export const ConsortiumManagerHeader = () => {
   const paneTitleRef = useRef();
+  const [selectMembersDisabled, setSelectMembersDisabled] = useState();
   const {
     affiliations,
+    eventEmitterRef,
     selectedMembers,
     selectMembers,
-    selectMembersDisabled,
   } = useConsortiumManagerContext();
+
+  useEffect(() => {
+    const eventType = EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS;
+    const callback = ({ detail }) => setSelectMembersDisabled(detail);
+
+    eventEmitterRef.current.on(eventType, callback);
+
+    return () => {
+      eventEmitterRef.current.off(eventType, callback);
+    }
+  })
 
   const records = useMemo(() => (
     affiliations.map(({ tenantId, tenantName }) => ({ id: tenantId, name: tenantName }))

--- a/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.js
+++ b/src/components/ConsortiumManagerHeader/ConsortiumManagerHeader.js
@@ -13,16 +13,17 @@ import {
 
 import { EVENT_EMITTER_EVENTS } from '../../constants';
 import { useConsortiumManagerContext } from '../../contexts';
+import { useEventEmitter } from '../../hooks';
 import { FindConsortiumMember } from '../FindConsortiumMember';
 
 import css from './ConsortiumManagerHeader.css';
 
 export const ConsortiumManagerHeader = () => {
   const paneTitleRef = useRef();
+  const eventEmitter = useEventEmitter();
   const [selectMembersDisabled, setSelectMembersDisabled] = useState();
   const {
     affiliations,
-    eventEmitterRef,
     selectedMembers,
     selectMembers,
   } = useConsortiumManagerContext();
@@ -31,12 +32,12 @@ export const ConsortiumManagerHeader = () => {
     const eventType = EVENT_EMITTER_EVENTS.DISABLE_SELECT_MEMBERS;
     const callback = ({ detail }) => setSelectMembersDisabled(detail);
 
-    eventEmitterRef.current.on(eventType, callback);
+    eventEmitter.on(eventType, callback);
 
     return () => {
-      eventEmitterRef.current.off(eventType, callback);
+      eventEmitter.off(eventType, callback);
     }
-  })
+  }, []);
 
   const records = useMemo(() => (
     affiliations.map(({ tenantId, tenantName }) => ({ id: tenantId, name: tenantName }))

--- a/src/constants.js
+++ b/src/constants.js
@@ -89,3 +89,7 @@ export const HTTP_METHODS = {
 };
 
 export const UNIQUE_FIELD_KEY = '__key__';
+
+export const EVENT_EMITTER_EVENTS = {
+  DISABLE_SELECT_MEMBERS: 'disable-consortium-manager-members-selection',
+};

--- a/src/contexts/ConsortiumManagerContext.js
+++ b/src/contexts/ConsortiumManagerContext.js
@@ -4,7 +4,6 @@ import {
   useCallback,
   useContext,
   useMemo,
-  useRef,
 } from 'react';
 
 import {
@@ -16,7 +15,6 @@ import {
   useCurrentUserTenantsPermissions,
   useUserAffiliations,
 } from '../hooks';
-import { EventEmitter } from '../utils';
 
 const DEFAULT_SELECTED_MEMBERS = [];
 
@@ -24,7 +22,6 @@ export const ConsortiumManagerContext = createContext();
 
 export const ConsortiumManagerContextProvider = ({ children }) => {
   const stripes = useStripes();
-  const eventEmitterRef = useRef(new EventEmitter());
   const selectedMembers = stripes?.user?.user?.selectedConsortiumMembers;
   const userId = stripes?.user?.user?.id;
 
@@ -79,7 +76,6 @@ export const ConsortiumManagerContextProvider = ({ children }) => {
 
   const contextValue = useMemo(() => ({
     affiliations,
-    eventEmitterRef: eventEmitterRef,
     hasPerm,
     isFetching,
     permissionNamesMap,

--- a/src/contexts/ConsortiumManagerContext.js
+++ b/src/contexts/ConsortiumManagerContext.js
@@ -4,7 +4,7 @@ import {
   useCallback,
   useContext,
   useMemo,
-  useState,
+  useRef,
 } from 'react';
 
 import {
@@ -16,6 +16,7 @@ import {
   useCurrentUserTenantsPermissions,
   useUserAffiliations,
 } from '../hooks';
+import { EventEmitter } from '../utils';
 
 const DEFAULT_SELECTED_MEMBERS = [];
 
@@ -23,7 +24,7 @@ export const ConsortiumManagerContext = createContext();
 
 export const ConsortiumManagerContextProvider = ({ children }) => {
   const stripes = useStripes();
-  const [selectMembersDisabled, setSelectMembersDisabled] = useState();
+  const eventEmitterRef = useRef(new EventEmitter());
   const selectedMembers = stripes?.user?.user?.selectedConsortiumMembers;
   const userId = stripes?.user?.user?.id;
 
@@ -78,21 +79,18 @@ export const ConsortiumManagerContextProvider = ({ children }) => {
 
   const contextValue = useMemo(() => ({
     affiliations,
+    eventEmitterRef: eventEmitterRef,
     hasPerm,
     isFetching,
     permissionNamesMap,
     selectedMembers: selectedMembers || DEFAULT_SELECTED_MEMBERS,
     selectMembers,
-    selectMembersDisabled,
-    setSelectMembersDisabled,
   }), [
     affiliations,
     hasPerm,
     isFetching,
     permissionNamesMap,
     selectMembers,
-    selectMembersDisabled,
-    selectedMembers,
   ]);
 
   return (

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,5 +1,6 @@
 export { useCurrentConsortium } from './useCurrentConsortium';
 export { useCurrentUserTenantsPermissions } from './useCurrentUserTenantsPermissions';
+export { useEventEmitter } from './useEventEmitter';
 export { usePublishCoordinator } from './usePublishCoordinator';
 export { useTenantKy } from './useTenantKy';
 export { useTenantPermissions } from './useTenantPermissions';

--- a/src/hooks/useEventEmitter/index.js
+++ b/src/hooks/useEventEmitter/index.js
@@ -1,0 +1,1 @@
+export { useEventEmitter } from './useEventEmitter';

--- a/src/hooks/useEventEmitter/useEventEmitter.js
+++ b/src/hooks/useEventEmitter/useEventEmitter.js
@@ -1,0 +1,7 @@
+import { EventEmitter } from '../../utils';
+
+const eventEmitter = new EventEmitter();
+
+export const useEventEmitter = () => {
+  return eventEmitter;
+}

--- a/src/hooks/useEventEmitter/useEventEmitter.test.js
+++ b/src/hooks/useEventEmitter/useEventEmitter.test.js
@@ -1,0 +1,11 @@
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+
+import { useEventEmitter } from './useEventEmitter';
+
+describe('useEventEmitter', () => {
+  it('should ', async () => {
+    const { result } = renderHook(() => useEventEmitter());
+
+    // expect(result.current).toBe(kyMock);
+  });
+});

--- a/src/hooks/useEventEmitter/useEventEmitter.test.js
+++ b/src/hooks/useEventEmitter/useEventEmitter.test.js
@@ -1,11 +1,12 @@
 import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
 
+import { EventEmitter } from '../../utils';
 import { useEventEmitter } from './useEventEmitter';
 
 describe('useEventEmitter', () => {
-  it('should ', async () => {
+  it('should return event emitter instance', async () => {
     const { result } = renderHook(() => useEventEmitter());
 
-    // expect(result.current).toBe(kyMock);
+    expect(result.current).toBeInstanceOf(EventEmitter);
   });
 });

--- a/src/routes/ConsortiumManager/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.test.js
@@ -13,6 +13,7 @@ import {
 } from 'fixtures';
 import { buildStripesObject } from 'helpers';
 import { ConsortiumManagerContext } from '../../contexts';
+import { EventEmitter } from '../../utils';
 import { ConsortiumManager } from './ConsortiumManager';
 import { AVAILABLE_SETTINGS } from './constants';
 
@@ -37,6 +38,7 @@ jest.mock('./settings/users/general', () => ({
 const defaultProps = {};
 const context = {
   affiliations,
+  eventEmitterRef: { current: new EventEmitter() },
   selectedMembers: tenants.slice(3),
   selectMembers: jest.fn(),
   selectMembersDisabled: false,

--- a/src/routes/ConsortiumManager/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.test.js
@@ -38,7 +38,6 @@ jest.mock('./settings/users/general', () => ({
 const defaultProps = {};
 const context = {
   affiliations,
-  eventEmitterRef: { current: new EventEmitter() },
   selectedMembers: tenants.slice(3),
   selectMembers: jest.fn(),
   selectMembersDisabled: false,

--- a/src/routes/ConsortiumManager/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.test.js
@@ -13,7 +13,6 @@ import {
 } from 'fixtures';
 import { buildStripesObject } from 'helpers';
 import { ConsortiumManagerContext } from '../../contexts';
-import { EventEmitter } from '../../utils';
 import { ConsortiumManager } from './ConsortiumManager';
 import { AVAILABLE_SETTINGS } from './constants';
 
@@ -23,6 +22,7 @@ jest.mock('@folio/stripes/core', () => ({
   useStripes: jest.fn(),
 }));
 jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
   useTenantPermissions: jest.fn(() => ({ permissions: [], isLoading: false, isFetching: false })),
 }));
 jest.mock('./settings/data-export/hooks', () => ({

--- a/src/utils/EventEmitter.js
+++ b/src/utils/EventEmitter.js
@@ -1,0 +1,19 @@
+export class EventEmitter {
+  constructor() {
+    this.eventTarget = new EventTarget();
+  }
+
+  on(eventName, callback) {
+    this.eventTarget.addEventListener(eventName, callback);
+  }
+
+  off(eventName, callback) {
+    this.eventTarget.removeEventListener(eventName, callback);
+  }
+
+  emit(eventName, data) {
+    const event = new CustomEvent(eventName, { detail: data });
+
+    this.eventTarget.dispatchEvent(event);
+  }
+}

--- a/src/utils/EventEmitter.test.js
+++ b/src/utils/EventEmitter.test.js
@@ -1,0 +1,37 @@
+import { EventEmitter } from './EventEmitter';
+
+describe('EventEmitter', () => {
+  let emitter;
+  let callback;
+
+  beforeEach(() => {
+    emitter = new EventEmitter();
+    callback = jest.fn();
+  });
+
+  afterEach(() => {
+    callback.mockReset();
+  });
+
+  it('should add and invoke event listeners', () => {
+    emitter.on('customEvent', callback);
+    emitter.emit('customEvent', 'test data');
+
+    expect(callback).toHaveBeenCalledWith('test data');
+  });
+
+  it('should remove event listeners', () => {
+    emitter.on('customEvent', callback);
+    emitter.off('customEvent', callback);
+    emitter.emit('customEvent', 'test data');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should emit events with the correct data', () => {
+    emitter.on('customEvent', callback);
+    emitter.emit('customEvent', 'test data');
+
+    expect(callback).toHaveBeenCalledWith('test data');
+  });
+});

--- a/src/utils/EventEmitter.test.js
+++ b/src/utils/EventEmitter.test.js
@@ -1,37 +1,36 @@
 import { EventEmitter } from './EventEmitter';
 
+const EVENT_TYPE = 'test-event-type';
+const callback = jest.fn();
+const payload = 'Test payload';
+
 describe('EventEmitter', () => {
   let emitter;
-  let callback;
 
   beforeEach(() => {
     emitter = new EventEmitter();
-    callback = jest.fn();
-  });
-
-  afterEach(() => {
-    callback.mockReset();
+    callback.mockClear();
   });
 
   it('should add and invoke event listeners', () => {
-    emitter.on('customEvent', callback);
-    emitter.emit('customEvent', 'test data');
+    emitter.on(EVENT_TYPE, callback);
+    emitter.emit(EVENT_TYPE, payload);
 
-    expect(callback).toHaveBeenCalledWith('test data');
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ detail: payload }));
   });
 
   it('should remove event listeners', () => {
-    emitter.on('customEvent', callback);
-    emitter.off('customEvent', callback);
-    emitter.emit('customEvent', 'test data');
+    emitter.on(EVENT_TYPE, callback);
+    emitter.off(EVENT_TYPE, callback);
+    emitter.emit(EVENT_TYPE, payload);
 
     expect(callback).not.toHaveBeenCalled();
   });
 
   it('should emit events with the correct data', () => {
-    emitter.on('customEvent', callback);
-    emitter.emit('customEvent', 'test data');
+    emitter.on(EVENT_TYPE, callback);
+    emitter.emit(EVENT_TYPE, payload);
 
-    expect(callback).toHaveBeenCalledWith('test data');
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ detail: payload }));
   });
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 export { checkConsortiumAffiliations } from './checkConsortiumAffiliations';
+export { EventEmitter } from './EventEmitter';
 export { getCurrentModulePath } from './getCurrentModulePath';
 export { getLegacyTokenHeader } from './getLegacyTokenHeader';
 export { getModuleName } from './getModuleName';

--- a/test/jest/helpers/ConsortiumManagerContextProviderMock.js
+++ b/test/jest/helpers/ConsortiumManagerContextProviderMock.js
@@ -1,10 +1,8 @@
 import { ConsortiumManagerContext } from '../../../src/contexts';
-import { EventEmitter } from '../../../src/utils';
 import { affiliations, tenants } from '../fixtures';
 
 const defaultContext = {
   affiliations,
-  eventEmitterRef: { current: new EventEmitter() },
   hasPerm: jest.fn(() => true),
   permissionNamesMap: tenants.reduce((acc, { id }) => ({
     ...acc,

--- a/test/jest/helpers/ConsortiumManagerContextProviderMock.js
+++ b/test/jest/helpers/ConsortiumManagerContextProviderMock.js
@@ -1,8 +1,10 @@
 import { ConsortiumManagerContext } from '../../../src/contexts';
+import { EventEmitter } from '../../../src/utils';
 import { affiliations, tenants } from '../fixtures';
 
 const defaultContext = {
   affiliations,
+  eventEmitterRef: { current: new EventEmitter() },
   hasPerm: jest.fn(() => true),
   permissionNamesMap: tenants.reduce((acc, { id }) => ({
     ...acc,
@@ -14,8 +16,6 @@ const defaultContext = {
   }), {}),
   selectedMembers: tenants.slice(3),
   selectMembers: jest.fn(),
-  selectMembersDisabled: false,
-  setSelectMembersDisabled: jest.fn(),
 };
 
 export const ConsortiumManagerContextProviderMock = ({ children, context = defaultContext }) => (


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UICONSET-112

Updating the state of the "Select members" button results in rerenders in all sub-trees, which causes issues in displaying the editable list component (for some reason re-render affects the internal state of the form).

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Keep the state (disabled) of the "Select members" button in the `<ConsortiumManagerHeader />`. Implement `EventEmitter` (based on Web API's `CustomEvent`) to handle disabling the button outside the component.

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

### with `useState` in consortium manager context


https://github.com/folio-org/ui-consortia-settings/assets/88109087/24ba38c6-fcd3-4413-9f65-27f8873991e3

### with `EventEmitter`

https://github.com/folio-org/ui-consortia-settings/assets/88109087/05096b0a-8f18-45f9-943c-ede35a1a0bf0

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
- `CustomEvent` API - https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
- `EventTarget` API  - https://developer.mozilla.org/en-US/docs/Web/API/EventTarget

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
