### PR TITLE
UICONSET-139: Consortia-settings: format numbers in "totalRecords" columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
 * [UICONSET-138](https://issues.folio.org/browse/UICONSET-138) Upgrade `React` to `v18`
 * [UICONSET-137](https://issues.folio.org/browse/UICONSET-137) Update `Node.js` to `v18`s in GitHub Actions.
 * [UICONSET-112](https://issues.folio.org/browse/UICONSET-112) Allow a user to delete shared settings in the `<ConsortiaControlledVocabulary>`.
+* [UICONSET-139](https://issues.folio.org/browse/UICONSET-139) Consortia-settings: format numbers in "totalRecords" columns.

--- a/src/routes/ConsortiumManager/settings/data-export/DataExportLogs/DataExportLogs.test.js
+++ b/src/routes/ConsortiumManager/settings/data-export/DataExportLogs/DataExportLogs.test.js
@@ -27,6 +27,11 @@ jest.mock('@folio/stripes-data-transfer-components', () => ({
   useJobLogsListFormatter: jest.fn(),
 }));
 
+jest.mock('../utils', ()=>({
+  ...jest.requireActual('../utils'),
+  getExportJobLogsListResultsFormatter: jest.fn(),
+}))
+
 jest.mock('../hooks', () => ({
   ...jest.requireActual('../hooks'),
   useDataExportLogs: jest.fn(),

--- a/src/routes/ConsortiumManager/settings/data-export/utils.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.js
@@ -15,7 +15,7 @@ export const getExportJobLogsListResultsFormatter = ({ intl }) => ({
 
     switch (true) {
       case failedSrs === 0 && failedOther > 0:
-        return `${failedOther}`;
+        return failedOther;
       case failedSrs > 0 && failedOther > 0:
         return intl.formatMessage({
           id: 'ui-consortia-settings.duplicatesWithOthers',

--- a/src/routes/ConsortiumManager/settings/data-export/utils.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.js
@@ -9,7 +9,21 @@ export const getExportJobLogsListResultsFormatter = ({ intl }) => ({
   [EXPORT_JOB_LOG_COLUMNS.status]: record => intl.formatMessage({ id: `ui-data-export.jobStatus.${camelCase(record.status)}` }),
   [EXPORT_JOB_LOG_COLUMNS.runBy]: record => getFullName({ personal: record.runBy }).trim(),
   [EXPORT_JOB_LOG_COLUMNS.totalRecords]: record => intl.formatNumber(record.progress?.total),
-  [EXPORT_JOB_LOG_COLUMNS.errors]: record => record.progress?.failed || '',
+  [EXPORT_JOB_LOG_COLUMNS.errors]: record => {
+    const failedSrs = record.progress?.failed?.duplicatedSrs;
+    const failedOther = record.progress?.failed?.otherFailed;
+
+    switch (true) {
+      case failedSrs === 0 && failedOther > 0:
+        return `${failedOther}`;
+      case failedSrs > 0 && failedOther > 0:
+        return `${failedOther}, ${failedSrs} duplicates`;
+      case failedSrs > 0 && failedOther === 0:
+        return `${failedSrs} duplicates`;
+      default:
+        return '';
+    }
+  },
   [EXPORT_JOB_LOG_COLUMNS.exported]: record => record.progress?.exported || '',
 });
 

--- a/src/routes/ConsortiumManager/settings/data-export/utils.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.js
@@ -8,7 +8,7 @@ export const getExportJobLogsListResultsFormatter = ({ intl }) => ({
   [EXPORT_JOB_LOG_COLUMNS.fileName]: record => record.exportedFiles?.[0]?.fileName,
   [EXPORT_JOB_LOG_COLUMNS.status]: record => intl.formatMessage({ id: `ui-data-export.jobStatus.${camelCase(record.status)}` }),
   [EXPORT_JOB_LOG_COLUMNS.runBy]: record => getFullName({ personal: record.runBy }).trim(),
-  [EXPORT_JOB_LOG_COLUMNS.totalRecords]: record => record.progress?.total,
+  [EXPORT_JOB_LOG_COLUMNS.totalRecords]: record => intl.formatNumber(record.progress?.total),
   [EXPORT_JOB_LOG_COLUMNS.errors]: record => record.progress?.failed || '',
   [EXPORT_JOB_LOG_COLUMNS.exported]: record => record.progress?.exported || '',
 });

--- a/src/routes/ConsortiumManager/settings/data-export/utils.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.js
@@ -17,9 +17,18 @@ export const getExportJobLogsListResultsFormatter = ({ intl }) => ({
       case failedSrs === 0 && failedOther > 0:
         return `${failedOther}`;
       case failedSrs > 0 && failedOther > 0:
-        return `${failedOther}, ${failedSrs} duplicates`;
+        return intl.formatMessage({
+          id: 'ui-consortia-settings.duplicatesWithOthers',
+        }, {
+          failedOther,
+          failedSrs,
+        });
       case failedSrs > 0 && failedOther === 0:
-        return `${failedSrs} duplicates`;
+        return intl.formatMessage({
+          id: 'ui-consortia-settings.duplicates',
+        }, {
+          failedSrs,
+        });
       default:
         return '';
     }

--- a/src/routes/ConsortiumManager/settings/data-export/utils.test.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.test.js
@@ -17,7 +17,7 @@ describe('getExportJobLogsListResultsFormatter', () => {
     const result3 = formatter[EXPORT_JOB_LOG_COLUMNS.errors](record3);
 
     // Assert based on the expected error messages for each scenario
-    expect(result1).toBe('5');
+    expect(result1).toBe(5);
     expect(result2).toBe('ui-consortia-settings.duplicatesWithOthers'); // Replace 'formattedError' with the expected error message
     expect(result3).toBe('ui-consortia-settings.duplicates'); // Replace 'formattedError' with the expected error message
   });

--- a/src/routes/ConsortiumManager/settings/data-export/utils.test.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.test.js
@@ -1,0 +1,25 @@
+import {getExportJobLogsListResultsFormatter} from './utils'
+import {EXPORT_JOB_LOG_COLUMNS} from "./constants";
+import {useIntl} from "react-intl";
+
+describe('getExportJobLogsListResultsFormatter', () => {
+  const intl = useIntl()
+
+  it('formats the errors correctly', () => {
+    const formatter = getExportJobLogsListResultsFormatter({ intl });
+    // Test cases for different error scenarios
+    const record1 = { progress: { failed: { duplicatedSrs: 0, otherFailed: 5 } } };
+    const record2 = { progress: { failed: { duplicatedSrs: 3, otherFailed: 5 } } };
+    const record3 = { progress: { failed: { duplicatedSrs: 3, otherFailed: 0 } } };
+
+    const result1 = formatter[EXPORT_JOB_LOG_COLUMNS.errors](record1);
+    const result2 = formatter[EXPORT_JOB_LOG_COLUMNS.errors](record2);
+    const result3 = formatter[EXPORT_JOB_LOG_COLUMNS.errors](record3);
+
+    // Assert based on the expected error messages for each scenario
+    expect(result1).toBe('5');
+    expect(result2).toBe('ui-consortia-settings.duplicatesWithOthers'); // Replace 'formattedError' with the expected error message
+    expect(result3).toBe('ui-consortia-settings.duplicates'); // Replace 'formattedError' with the expected error message
+  });
+});
+

--- a/translations/ui-consortia-settings/en.json
+++ b/translations/ui-consortia-settings/en.json
@@ -12,6 +12,9 @@
 
   "code": "Code",
 
+  "duplicatesWithOthers": "{failedOther}, {failedSrs} duplicates",
+  "duplicates": "{failedSrs} duplicates",
+
   "consortiumManager.all": "All",
   "consortiumManager.controlledVocab.column.memberLibraries": "Member libraries",
   "consortiumManager.controlledVocab.common.termCreated": "<b>{term}</b> was successfully <b>created</b> for <b>{members}</b> {count, select, 1 {library} other {libraries}}.",
@@ -118,7 +121,7 @@
   "consortiumManager.controlledVocab.URLrelationship.deleteEntry": "Delete URL relationship term",
   "consortiumManager.controlledVocab.URLrelationship.termDeleted": "The URL relationship term <b>{term}</b> was successfully <b>deleted</b>.",
   "consortiumManager.controlledVocab.URLrelationship.termWillBeDeleted": "The URL relationship term <b>{term}</b> will be <b>deleted</b>.",
-  
+
   "consortiumManager.error.forbiddenMembers": "You do not have permissions at one or more members: <b>{members}</b>",
 
   "consortiumManager.findMember.trigger.label": "Select members",


### PR DESCRIPTION
UICONSET-139: Consortia-settings: format numbers in "totalRecords" columns

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->
[UICONSET-139](https://issues.folio.org/browse/UICONSET-139)
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
