### PR TITLE
UICONSET-143 Display error toast message for all action types that has partial failed results

### DIFF
--- a/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.test.js
+++ b/src/components/ConsortiaControlledVocabulary/ConsortiaControlledVocabulary.test.js
@@ -174,14 +174,14 @@ wrapConsortiaControlledVocabularyDescribe({ entries: response[records] })('Conso
           values: expect.objectContaining({
             count: 1,
             term: response[records][2].foo,
-          })
+          }),
         });
       });
 
       it('should handle shared record deletion - partial failure', async () => {
         sharing.deleteSharedSetting.mockResolvedValue({
           ...pcPublicationResults,
-          publicationErrors: [{ tenantId: 'another', }],
+          publicationErrors: [{ tenantId: 'another' }],
         });
 
         renderConsortiaControlledVocabulary();

--- a/src/routes/ConsortiumManager/settings/data-export/DataExportLogs/DataExportLogs.test.js
+++ b/src/routes/ConsortiumManager/settings/data-export/DataExportLogs/DataExportLogs.test.js
@@ -27,10 +27,10 @@ jest.mock('@folio/stripes-data-transfer-components', () => ({
   useJobLogsListFormatter: jest.fn(),
 }));
 
-jest.mock('../utils', ()=>({
+jest.mock('../utils', () => ({
   ...jest.requireActual('../utils'),
   getExportJobLogsListResultsFormatter: jest.fn(),
-}))
+}));
 
 jest.mock('../hooks', () => ({
   ...jest.requireActual('../hooks'),

--- a/src/routes/ConsortiumManager/settings/data-export/utils.test.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.test.js
@@ -1,12 +1,11 @@
-import {getExportJobLogsListResultsFormatter} from './utils'
-import {EXPORT_JOB_LOG_COLUMNS} from "./constants";
-import {useIntl} from "react-intl";
+import { getExportJobLogsListResultsFormatter } from './utils';
+import { EXPORT_JOB_LOG_COLUMNS } from './constants';
 
 describe('getExportJobLogsListResultsFormatter', () => {
   const intl = {
-    formatNumber: jest.fn(arg=>  Number(arg)),
-    formatMessage: jest.fn(({id})=> id)
-  }
+    formatNumber: jest.fn(arg => Number(arg)),
+    formatMessage: jest.fn(({ id }) => id),
+  };
 
   it('formats the errors correctly', () => {
     const formatter = getExportJobLogsListResultsFormatter({ intl });
@@ -25,4 +24,3 @@ describe('getExportJobLogsListResultsFormatter', () => {
     expect(result3).toBe('ui-consortia-settings.duplicates'); // Replace 'formattedError' with the expected error message
   });
 });
-

--- a/test/jest/helpers/wrapConsortiaControlledVocabularyDescribe.js
+++ b/test/jest/helpers/wrapConsortiaControlledVocabularyDescribe.js
@@ -5,7 +5,7 @@ import {
   useUsersBatch,
 } from '@folio/stripes-acq-components';
 
-import { pcPublicationResults } from 'fixtures'; 
+import { pcPublicationResults } from 'fixtures';
 import {
   useSettings,
   useSettingMutation,

--- a/translations/ui-consortia-settings/en.json
+++ b/translations/ui-consortia-settings/en.json
@@ -123,7 +123,9 @@
   "consortiumManager.controlledVocab.URLrelationship.termWillBeDeleted": "The URL relationship term <b>{term}</b> will be <b>deleted</b>.",
 
   "consortiumManager.error.forbiddenMembers": "You do not have permissions at one or more members: <b>{members}</b>",
-  "consortiumManager.error.share.partialFailure": "<b>{term}</b> could <b>not</b> be <b>deleted</b> from members: <b>{members}</b>, so the source has been changed to\u00a0<b>local</b>.",
+  "consortiumManager.error.publishCoordinator.partialFailure.create": "<b>{term}</b> was <b>not created</b> for members: <b>{members}</b>.",
+  "consortiumManager.error.publishCoordinator.partialFailure.delete": "<b>{term}</b> could <b>not</b> be <b>deleted</b> from members: <b>{members}</b>, so the source has been changed to\u00a0<b>local</b>.",
+  "consortiumManager.error.publishCoordinator.partialFailure.update": "<b>{term}</b> was <b>not updated</b> for members: <b>{members}</b>.",
 
   "consortiumManager.findMember.trigger.label": "Select members",
   "consortiumManager.findMember.modal.aria.search": "Search members",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UICONSET-143](https://issues.folio.org/browse/UICONSET-143)

Publish coordinator response might be successful for some tenants and failed for others. So a user should see a corresponding message.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Handle error results from publish coordinator response.

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-consortia-settings/assets/88109087/e38d054d-541d-44ed-971e-676c65986dd0


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
