### PR TITLE
UICONSET-172: Downloading Files from Consortia Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.0 (IN PROGRESS)
 
 * [UICONSET-152](https://folio-org.atlassian.net/browse/UICONSET-152) *BREAKING* Implement settings for central ordering across consortium.
+* [UICONSET-172](https://folio-org.atlassian.net/browse/UICONSET-172) Downloading Files from Consortia Manager
 
 ## [1.1.0](https://github.com/folio-org/ui-consortia-settings/tree/v1.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v1.0.2...v1.1.0)

--- a/src/routes/ConsortiumManager/ConsortiumManager.test.js
+++ b/src/routes/ConsortiumManager/ConsortiumManager.test.js
@@ -20,6 +20,7 @@ jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
   useModules: jest.fn(),
   useStripes: jest.fn(),
+  useOkapiKy: jest.fn(),
 }));
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
@@ -33,6 +34,11 @@ jest.mock('./settings/data-import/hooks', () => ({
 }));
 jest.mock('./settings/users/general', () => ({
   PermissionSets: jest.fn(() => 'PermissionSets'),
+}));
+
+jest.mock('./settings/data-export/utils', () => ({
+  ...jest.requireActual('./settings/data-export/utils'),
+  getExportJobLogsListResultsFormatter: jest.fn(),
 }));
 
 const defaultProps = {};
@@ -97,7 +103,7 @@ describe('ConsortiumManager', () => {
   });
 
   it.each(AVAILABLE_SETTINGS.map(module => [module]))('should render \'%s\' settings pane', async (name) => {
-    renderConsortiumManager();
+    await renderConsortiumManager();
 
     await userEvent.click(screen.getByText(name));
 

--- a/src/routes/ConsortiumManager/settings/data-export/DataExportLogs/DataExportLogs.js
+++ b/src/routes/ConsortiumManager/settings/data-export/DataExportLogs/DataExportLogs.js
@@ -3,7 +3,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
-  AppIcon, useOkapiKy,
+  AppIcon,
+  useOkapiKy,
 } from '@folio/stripes/core';
 import {
   Loading,

--- a/src/routes/ConsortiumManager/settings/data-export/DataExportLogs/DataExportLogs.js
+++ b/src/routes/ConsortiumManager/settings/data-export/DataExportLogs/DataExportLogs.js
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
-  AppIcon,
+  AppIcon, useOkapiKy,
 } from '@folio/stripes/core';
 import {
   Loading,
@@ -40,6 +40,7 @@ import css from './DataExportLogs.css';
 
 export const DataExportLogs = () => {
   const intl = useIntl();
+  const ky = useOkapiKy();
   const showCallout = useShowCallout();
 
   const {
@@ -96,7 +97,7 @@ export const DataExportLogs = () => {
     columnWidths: EXPORT_JOB_LOG_COLUMNS_WIDTHS,
     columnMapping: EXPORT_JOB_LOG_COLUMN_MAPPING,
   });
-  const formatter = useJobLogsListFormatter(getExportJobLogsListResultsFormatter({ intl }));
+  const formatter = useJobLogsListFormatter(getExportJobLogsListResultsFormatter({ intl, ky }));
   const listProps = useMemo(() => ({
     ...jobLogsProperties,
     formatter,

--- a/src/routes/ConsortiumManager/settings/data-export/utils.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.js
@@ -44,7 +44,7 @@ const downloadExportFile = async (record, ky) => {
   }
 };
 
-const getFileNameField = (record, ky) => {
+export const getFileNameField = (record, ky) => {
   const fileName = get(record.exportedFiles, '0.fileName');
 
   return (

--- a/src/routes/ConsortiumManager/settings/data-export/utils.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.js
@@ -1,11 +1,68 @@
 import camelCase from 'lodash/camelCase';
+import { get } from 'lodash';
 
+import { TextLink } from '@folio/stripes/components';
 import { getFullName } from '@folio/stripes/util';
 
 import { EXPORT_JOB_LOG_COLUMNS } from './constants';
 
-export const getExportJobLogsListResultsFormatter = ({ intl }) => ({
-  [EXPORT_JOB_LOG_COLUMNS.fileName]: record => record.exportedFiles?.[0]?.fileName,
+export const downloadFileByLink = (fileName, downloadLink) => {
+  if (!fileName || !downloadLink) return;
+
+  const elem = window.document.createElement('a');
+
+  elem.href = downloadLink;
+  elem.download = fileName;
+  elem.style.display = 'none';
+  document.body.appendChild(elem);
+
+  elem.click();
+
+  document.body.removeChild(elem);
+};
+
+export const getFileLink = async (jobLog, ky) => {
+  const response = await ky.get(`data-export/job-executions/${jobLog.id}/download/${jobLog.exportedFiles[0].fileId}`);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { link } = await response.json();
+
+  return link;
+};
+
+const downloadExportFile = async (record, ky) => {
+  try {
+    const fileName = get(record.exportedFiles, '0.fileName');
+    const downloadLink = await getFileLink(record, ky);
+
+    downloadFileByLink(fileName, downloadLink);
+  } catch (error) {
+    console.error(error); // eslint-disable-line no-console
+  }
+};
+
+const getFileNameField = (record, ky) => {
+  const fileName = get(record.exportedFiles, '0.fileName');
+
+  return (
+    record.progress?.exported ? (
+      <TextLink
+        onClick={() => downloadExportFile(record, ky)}
+        data-testid="text-link"
+      >
+        {fileName}
+      </TextLink>
+    ) : (
+      <span>{fileName}</span>
+    )
+  );
+};
+
+export const getExportJobLogsListResultsFormatter = ({ intl, ky }) => ({
+  [EXPORT_JOB_LOG_COLUMNS.fileName]: record => getFileNameField(record, ky),
   [EXPORT_JOB_LOG_COLUMNS.status]: record => intl.formatMessage({ id: `ui-data-export.jobStatus.${camelCase(record.status)}` }),
   [EXPORT_JOB_LOG_COLUMNS.runBy]: record => getFullName({ personal: record.runBy }).trim(),
   [EXPORT_JOB_LOG_COLUMNS.totalRecords]: record => intl.formatNumber(record.progress?.total),

--- a/src/routes/ConsortiumManager/settings/data-export/utils.test.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.test.js
@@ -1,4 +1,4 @@
-import { getExportJobLogsListResultsFormatter } from './utils';
+import {downloadFileByLink, getExportJobLogsListResultsFormatter, getFileLink} from './utils';
 import { EXPORT_JOB_LOG_COLUMNS } from './constants';
 
 describe('getExportJobLogsListResultsFormatter', () => {
@@ -22,5 +22,59 @@ describe('getExportJobLogsListResultsFormatter', () => {
     expect(result1).toBe(5);
     expect(result2).toBe('ui-consortia-settings.duplicatesWithOthers'); // Replace 'formattedError' with the expected error message
     expect(result3).toBe('ui-consortia-settings.duplicates'); // Replace 'formattedError' with the expected error message
+  });
+});
+
+describe('fileUtils', () => {
+  describe('downloadFileByLink', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('downloads a file given a valid fileName and downloadLink', () => {
+      const fileName = 'example.txt';
+      const downloadLink = 'https://example.com/download';
+
+      const createElementMock = jest.spyOn(document, 'createElement');
+      const appendChildMock = jest.spyOn(document.body, 'appendChild');
+      const removeChildMock = jest.spyOn(document.body, 'removeChild');
+
+      downloadFileByLink(fileName, downloadLink);
+
+      expect(createElementMock).toHaveBeenCalledWith('a');
+      expect(appendChildMock).toHaveBeenCalled();
+      expect(removeChildMock).toHaveBeenCalled();
+    });
+
+    it('does not download if fileName or downloadLink is missing', () => {
+      const fileName = '';
+      const downloadLink = '';
+
+      const createElementMock = jest.spyOn(document, 'createElement');
+      const appendChildMock = jest.spyOn(document.body, 'appendChild');
+
+      downloadFileByLink(fileName, downloadLink);
+
+      expect(createElementMock).not.toHaveBeenCalled();
+      expect(appendChildMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getFileLink', () => {
+    it('fetches the download link successfully', async () => {
+      const jobLog = { id: '123', exportedFiles: [{ fileId: '456' }] };
+      const expectedLink = 'https://example.com/download';
+
+      const ky = {
+        get: jest.fn(),
+      }
+
+      ky.get.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ link: expectedLink }) });
+
+      const link = await getFileLink(jobLog, ky);
+
+      expect(link).toBe(expectedLink);
+      expect(ky.get).toHaveBeenCalledWith('data-export/job-executions/123/download/456');
+    });
   });
 });

--- a/src/routes/ConsortiumManager/settings/data-export/utils.test.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.test.js
@@ -83,6 +83,23 @@ describe('fileUtils', () => {
       expect(ky.get).toHaveBeenCalledWith('data-export/job-executions/123/download/456');
     });
   });
+
+  it('throws an error when response is not successful', async () => {
+    const jobLog = { id: '123', exportedFiles: [{ fileId: '456' }] };
+
+    const ky = {
+      get: jest.fn(),
+    };
+
+    ky.get.mockResolvedValueOnce({ ok: false, statusText: 'Not Found' });
+
+    try {
+      await getFileLink(jobLog, ky);
+      expect(true).toBe(false); // This line should not be reached
+    } catch (error) {
+      expect(error).toEqual({ ok: false, statusText: 'Not Found' });
+    }
+  });
 });
 
 describe('getFileNameField', () => {

--- a/src/routes/ConsortiumManager/settings/data-export/utils.test.js
+++ b/src/routes/ConsortiumManager/settings/data-export/utils.test.js
@@ -1,5 +1,11 @@
-import {downloadFileByLink, getExportJobLogsListResultsFormatter, getFileLink} from './utils';
+import {
+  downloadFileByLink,
+  getExportJobLogsListResultsFormatter,
+  getFileLink,
+  getFileNameField
+} from './utils';
 import { EXPORT_JOB_LOG_COLUMNS } from './constants';
+import {render} from "@folio/jest-config-stripes/testing-library/react";
 
 describe('getExportJobLogsListResultsFormatter', () => {
   const intl = {
@@ -76,5 +82,40 @@ describe('fileUtils', () => {
       expect(link).toBe(expectedLink);
       expect(ky.get).toHaveBeenCalledWith('data-export/job-executions/123/download/456');
     });
+  });
+});
+
+describe('getFileNameField', () => {
+  const recordWithExportedProgress = {
+    exportedFiles: [{ fileName: 'example.txt' }],
+    progress: { exported: true }
+  };
+
+  const recordWithoutExportedProgress = {
+    exportedFiles: [{ fileName: 'example.txt' }],
+    progress: { exported: false }
+  };
+
+  const kyMock = jest.fn(); // Mock the ky function if needed
+
+  it('renders TextLink component when record.progress.exported is true', () => {
+    const { getByTestId } = render(
+      getFileNameField(recordWithExportedProgress, kyMock)
+    );
+
+    const textLinkElement = getByTestId('text-link');
+
+    expect(textLinkElement).toBeInTheDocument();
+    expect(textLinkElement).toHaveTextContent('example.txt');
+  });
+
+  it('renders span element when record.progress.exported is false', () => {
+    const { getByText } = render(
+      getFileNameField(recordWithoutExportedProgress, kyMock)
+    );
+
+    const spanElement = getByText('example.txt');
+
+    expect(spanElement).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UICONSET-172
Here we added logic for downloading files from `data-export logs` as it is done in `ui-data-export.`

https://github.com/folio-org/ui-consortia-settings/assets/72550466/3e274db4-55eb-4b98-a29e-82e93ca8b25e

