### PR TITLE
UICONSET-178 Confirmation modal for enabling the central ordering setting across the consortium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UICONSET-152](https://folio-org.atlassian.net/browse/UICONSET-152) *BREAKING* Implement settings for central ordering across consortium.
 * [UICONSET-172](https://folio-org.atlassian.net/browse/UICONSET-172) Downloading Files from Consortia Manager
 * [UICONSET-163](https://folio-org.atlassian.net/browse/UICONSET-163) UX consistency: Use Save & close button label stripes-component translation key - all UI modules
+* [UICONSET-178](https://folio-org.atlassian.net/browse/UICONSET-178) Confirmation modal for enabling the central ordering setting across the consortium.
 
 ## [1.1.0](https://github.com/folio-org/ui-consortia-settings/tree/v1.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v1.0.2...v1.1.0)

--- a/src/settings/CentralOrdering/CentralOrdering.test.js
+++ b/src/settings/CentralOrdering/CentralOrdering.test.js
@@ -32,15 +32,14 @@ const mockKy = {
   })),
 };
 const mockData = { id: 'setting-id' };
+const confirmModalMessageRegEx = /alert.message .*confirmModal.message/;
 
 const handleConfirmModal = (confirm = true) => {
-  const name = confirm ? 'ui-consortia-settings.button.confirm' : 'stripes-components.cancel';
-
-  return user.click(screen.getByRole('button', { name }));
+  return user.click(screen.getByRole('button', { name: confirm ? /confirm/ : /cancel/ }));
 }
 
 const findCentralOrderingCheckbox = () => {
- return screen.findByRole('checkbox', { name: 'ui-consortia-settings.settings.centralOrdering.checkbox.label' });
+ return screen.findByRole('checkbox', { name: /checkbox.label/ });
 }
 
 describe('CentralOrdering', () => {
@@ -61,8 +60,8 @@ describe('CentralOrdering', () => {
   it('should display pane headings', () => {
     renderCentralOrderingSettings();
 
-    const paneTitle = screen.getByText('ui-consortia-settings.settings.centralOrdering.label');
-    const checkboxLabel = screen.getByText('ui-consortia-settings.settings.centralOrdering.checkbox.label');
+    const paneTitle = screen.getByText(/centralOrdering.label/);
+    const checkboxLabel = screen.getByText(/checkbox.label/);
 
     expect(paneTitle).toBeInTheDocument();
     expect(checkboxLabel).toBeInTheDocument();
@@ -83,12 +82,12 @@ describe('CentralOrdering', () => {
     renderCentralOrderingSettings();
 
     await user.click(await findCentralOrderingCheckbox());
-    expect(await screen.findByText('ui-consortia-settings.settings.centralOrdering.alert.message ui-consortia-settings.settings.centralOrdering.confirmModal.message')).toBeInTheDocument();
+    expect(await screen.findByText(confirmModalMessageRegEx)).toBeInTheDocument();
 
     await handleConfirmModal();
     expect(await findCentralOrderingCheckbox()).toBeChecked();
 
-    await user.click(await screen.findByRole('button', { name: 'stripes-core.button.save' }));
+    await user.click(await screen.findByRole('button', { name: /save/ }));
     expect(mockKy.post).toHaveBeenCalled();
   });
 
@@ -105,12 +104,12 @@ describe('CentralOrdering', () => {
     renderCentralOrderingSettings();
 
     await user.click(await findCentralOrderingCheckbox());
-    expect(await screen.findByText('ui-consortia-settings.settings.centralOrdering.alert.message ui-consortia-settings.settings.centralOrdering.confirmModal.message')).toBeInTheDocument();
+    expect(await screen.findByText(confirmModalMessageRegEx)).toBeInTheDocument();
 
     await handleConfirmModal();
     expect(await findCentralOrderingCheckbox()).toBeChecked();
 
-    await user.click(await screen.findByRole('button', { name: 'stripes-core.button.save' }));
+    await user.click(await screen.findByRole('button', { name: /save/ }));
     expect(mockKy.put).toHaveBeenCalled();
   });
 

--- a/src/settings/CentralOrdering/CentralOrdering.test.js
+++ b/src/settings/CentralOrdering/CentralOrdering.test.js
@@ -33,6 +33,16 @@ const mockKy = {
 };
 const mockData = { id: 'setting-id' };
 
+const handleConfirmModal = (confirm = true) => {
+  const name = confirm ? 'ui-consortia-settings.button.confirm' : 'stripes-components.cancel';
+
+  return user.click(screen.getByRole('button', { name }));
+}
+
+const findCentralOrderingCheckbox = () => {
+ return screen.findByRole('checkbox', { name: 'ui-consortia-settings.settings.centralOrdering.checkbox.label' });
+}
+
 describe('CentralOrdering', () => {
   beforeEach(() => {
     mockKy.put.mockClear();
@@ -72,13 +82,56 @@ describe('CentralOrdering', () => {
   it('should handle central ordering settings create', async () => {
     renderCentralOrderingSettings();
 
-    await user.click(await screen.findByRole('checkbox', { name: 'ui-consortia-settings.settings.centralOrdering.checkbox.label' }));
-    await user.click(await screen.findByRole('button', { name: 'stripes-core.button.save' }));
+    await user.click(await findCentralOrderingCheckbox());
+    expect(await screen.findByText('ui-consortia-settings.settings.centralOrdering.alert.message ui-consortia-settings.settings.centralOrdering.confirmModal.message')).toBeInTheDocument();
 
+    await handleConfirmModal();
+    expect(await findCentralOrderingCheckbox()).toBeChecked();
+
+    await user.click(await screen.findByRole('button', { name: 'stripes-core.button.save' }));
     expect(mockKy.post).toHaveBeenCalled();
   });
 
   it('should handle central ordering settings update', async () => {
+    useCentralOrderingSettings
+      .mockClear()
+      .mockReturnValue({
+        data: mockData,
+        isFetching: false,
+        enabled: false,
+        refetch: mockRefetch,
+      });
+
+    renderCentralOrderingSettings();
+
+    await user.click(await findCentralOrderingCheckbox());
+    expect(await screen.findByText('ui-consortia-settings.settings.centralOrdering.alert.message ui-consortia-settings.settings.centralOrdering.confirmModal.message')).toBeInTheDocument();
+
+    await handleConfirmModal();
+    expect(await findCentralOrderingCheckbox()).toBeChecked();
+
+    await user.click(await screen.findByRole('button', { name: 'stripes-core.button.save' }));
+    expect(mockKy.put).toHaveBeenCalled();
+  });
+
+  it('should NOT be checked if a user cancel confirmation modal', async () => {
+    useCentralOrderingSettings
+      .mockClear()
+      .mockReturnValue({
+        data: mockData,
+        isFetching: false,
+        enabled: false,
+        refetch: mockRefetch,
+      });
+
+    renderCentralOrderingSettings();
+
+    await user.click(await findCentralOrderingCheckbox());
+    await handleConfirmModal(false);
+    expect(await findCentralOrderingCheckbox()).not.toBeChecked();
+  });
+
+  it('should disable checkbox when central ordering is enabled', async () => {
     useCentralOrderingSettings
       .mockClear()
       .mockReturnValue({
@@ -90,9 +143,9 @@ describe('CentralOrdering', () => {
 
     renderCentralOrderingSettings();
 
-    await user.click(await screen.findByRole('checkbox', { name: 'ui-consortia-settings.settings.centralOrdering.checkbox.label' }));
-    await user.click(await screen.findByRole('button', { name: 'stripes-core.button.save' }));
+    const checkbox = await findCentralOrderingCheckbox();
 
-    expect(mockKy.put).toHaveBeenCalled();
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toBeDisabled();
   });
 });

--- a/src/settings/CentralOrdering/CentralOrderingForm.js
+++ b/src/settings/CentralOrdering/CentralOrderingForm.js
@@ -14,6 +14,8 @@ import {
   Button,
   Checkbox,
   Col,
+  ConfirmationModal,
+  MessageBanner,
   Pane,
   PaneFooter,
   PaneHeader,
@@ -24,19 +26,53 @@ import {
   useStripes,
 } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
+import { useToggle } from '@folio/stripes-acq-components';
+
+const CENTRAL_ORDERING_FIELD_NAME = 'enabled';
 
 const CentralOrderingForm = ({
+  form: { change },
   handleSubmit,
+  initialValues,
   pristine,
   submitting,
 }) => {
   const intl = useIntl();
   const paneTitleRef = useRef();
   const stripes = useStripes();
+  const confirmEnableSettingPromiseRef = useRef(Promise);
+
+  const [isConfirmEnableSettingModalOpen, toggleConfirmEnableSettingModal] = useToggle(false);
+
+  const isCentralOrderingDisabled = !stripes.hasPerm('ui-consortia-settings.settings.networkOrdering.edit') || initialValues[CENTRAL_ORDERING_FIELD_NAME];
+  const confirmCentralOrderingMessage = [
+    intl.formatMessage({ id: 'ui-consortia-settings.settings.centralOrdering.alert.message' }),
+    intl.formatMessage({ id: 'ui-consortia-settings.settings.centralOrdering.confirmModal.message' }),
+  ].join(' ');
 
   const handlePaneFocus = useCallback(() => {
     return paneTitleRef.current?.focus();
   }, []);
+
+  const handleCentralOrderingChange = useCallback(async ({ target }) => {
+    const checked = target?.checked;
+    const changeFieldValue = (value) => change(CENTRAL_ORDERING_FIELD_NAME, value);
+
+    if (checked) {
+      await new Promise((resolve, reject) => {
+        confirmEnableSettingPromiseRef.current = { resolve, reject };
+
+        toggleConfirmEnableSettingModal();
+      })
+        .then(() => {
+          changeFieldValue(true);
+          toggleConfirmEnableSettingModal();
+        })
+        .catch(toggleConfirmEnableSettingModal);
+    } else {
+      changeFieldValue(checked);
+    }
+  }, [change, toggleConfirmEnableSettingModal]);
 
   const paneFooter = useMemo(() => {
     const end = (
@@ -76,22 +112,42 @@ const CentralOrderingForm = ({
         record={intl.formatMessage({ id: 'ui-consortia-settings.settings.centralOrdering.label' })}
       />
       <Row>
+        {initialValues[CENTRAL_ORDERING_FIELD_NAME] && (
+          <Col xs={12}>
+            <MessageBanner type="warning">
+              <FormattedMessage id="ui-consortia-settings.settings.centralOrdering.alert.message" />
+            </MessageBanner>
+          </Col>
+        )}
         <Col xs={12}>
           <Field
             component={Checkbox}
             label={<FormattedMessage id="ui-consortia-settings.settings.centralOrdering.checkbox.label" />}
-            name="enabled"
+            name={CENTRAL_ORDERING_FIELD_NAME}
             type="checkbox"
-            disabled={!stripes.hasPerm('ui-consortia-settings.settings.networkOrdering.edit')}
+            disabled={isCentralOrderingDisabled}
+            onChange={handleCentralOrderingChange}
           />
         </Col>
       </Row>
+
+      <ConfirmationModal
+        id="enable-central-ordering-confirmation"
+        open={isConfirmEnableSettingModalOpen}
+        heading={intl.formatMessage({ id: 'ui-consortia-settings.settings.centralOrdering.label' })}
+        message={confirmCentralOrderingMessage}
+        confirmLabel={intl.formatMessage({ id: 'ui-consortia-settings.button.confirm' })}
+        onConfirm={confirmEnableSettingPromiseRef.current.resolve}
+        onCancel={confirmEnableSettingPromiseRef.current.reject}
+      />
     </Pane>
   );
 };
 
 CentralOrderingForm.propTypes = {
+  form: PropTypes.object.isRequired,
   handleSubmit: PropTypes.func.isRequired,
+  initialValues: PropTypes.object.isRequired,
   pristine: PropTypes.bool.isRequired,
   submitting: PropTypes.bool.isRequired,
 };

--- a/translations/ui-consortia-settings/en.json
+++ b/translations/ui-consortia-settings/en.json
@@ -169,6 +169,8 @@
 
   "settings.centralOrdering.label": "Central ordering",
   "settings.centralOrdering.checkbox.label": "Allow user to select locations from other affiliations for central orders",
+  "settings.centralOrdering.alert.message": "In this version of FOLIO, once activated this setting cannot be disabled.",
+  "settings.centralOrdering.confirmModal.message": "Are you sure you would like to activate this functionality?",
   "settings.centralOrdering.submit.success": "Central ordering setting was successfully updated",
   "settings.centralOrdering.submit.error.generic": "Central ordering setting update failed",
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UICONSET-178

In the current release, activating the "central ordering" setting in the consortium manager makes it impossible to deactivate. When the setting is activated, the behavior changes in some modules, and the logic for rolling back to the previous state is not defined. Therefore, the user should be notified about the impossibility of disabling the setting.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Intercept the checkbox change event, display a confirmation modal to a user, and change the setting state depending on the decision.

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-consortia-settings/assets/88109087/25c9f2b0-fdab-480d-aee0-8f5e0b06248d


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
