### PR TITLE
UICONSET-188: ECS-NON-OKAPI Hide "Permission sets" subheading from consortia manager navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [UICONSET-162](https://folio-org.atlassian.net/browse/UICONSET-162) Save, edit Authorization policies for consortium.
 * [UICONSET-185](https://folio-org.atlassian.net/browse/UICONSET-168) Split consortium manager's navigation links into sections.
 * [UICONSET-169](https://folio-org.atlassian.net/browse/UICONSET-169) Consortia manager - Duplicate authorization role.
+* [UICONSET-188](https://folio-org.atlassian.net/browse/UICONSET-188) ECS-NON-OKAPI Hide "Permission sets" subheading from consortia manager navigation.
 
 ## [1.1.0](https://github.com/folio-org/ui-consortia-settings/tree/v1.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v1.0.2...v1.1.0)

--- a/src/routes/ConsortiumManager/settings/users/UsersSettings.js
+++ b/src/routes/ConsortiumManager/settings/users/UsersSettings.js
@@ -1,43 +1,21 @@
-import sortBy from 'lodash/sortBy';
+import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { stripesShape } from '@folio/stripes/core';
 import { Settings } from '@folio/stripes/smart-components';
 
 import { MODULE_ROOT_ROUTE } from '../../../../constants';
-import {
-  Departments,
-  PatronGroups,
-  PermissionSets,
-} from './general';
-
-const sections = [
-  {
-    label: <FormattedMessage id="ui-users.settings.general" />,
-    pages: sortBy([
-      {
-        route: 'perms',
-        label: <FormattedMessage id="ui-users.settings.permissionSet" />,
-        component: PermissionSets,
-        perm: 'ui-users.settings.permsets.view',
-      },
-      {
-        route: 'groups',
-        label: <FormattedMessage id="ui-users.settings.patronGroups" />,
-        component: PatronGroups,
-        perm: 'ui-users.settings.usergroups.view',
-      },
-      {
-        route: 'departments',
-        label: <FormattedMessage id="ui-users.settings.departments" />,
-        component: Departments,
-        perm: 'ui-users.settings.departments.view',
-      },
-    ], ['label']),
-  },
-];
+import { isEurekaEnabled } from '../../../../utils';
+import { getSectionPages } from './constants';
 
 const UsersSettings = (props) => {
+  const isEureka = isEurekaEnabled(props.stripes);
+
+  const sections = useMemo(() => [{
+    label: <FormattedMessage id="ui-users.settings.general" />,
+    pages: getSectionPages(isEureka),
+  }], [isEureka]);
+
   return (
     <Settings
       {...props}

--- a/src/routes/ConsortiumManager/settings/users/constants.js
+++ b/src/routes/ConsortiumManager/settings/users/constants.js
@@ -1,0 +1,46 @@
+import sortBy from 'lodash/sortBy';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Departments,
+  PatronGroups,
+  PermissionSets,
+} from './general';
+
+export const SECTION_NAMES = {
+  departments: 'departments',
+  groups: 'groups',
+  perms: 'perms',
+};
+
+export const SECTION_PAGES = [
+  {
+    route: SECTION_NAMES.perms,
+    label: <FormattedMessage id="ui-users.settings.permissionSet" />,
+    component: PermissionSets,
+    perm: 'ui-users.settings.permsets.view',
+    isEurekaEnabled: false,
+  },
+  {
+    route: SECTION_NAMES.groups,
+    label: <FormattedMessage id="ui-users.settings.patronGroups" />,
+    component: PatronGroups,
+    perm: 'ui-users.settings.usergroups.view',
+    isEurekaEnabled: true,
+  },
+  {
+    route: SECTION_NAMES.departments,
+    label: <FormattedMessage id="ui-users.settings.departments" />,
+    component: Departments,
+    perm: 'ui-users.settings.departments.view',
+    isEurekaEnabled: true,
+  },
+];
+
+export const getSectionPages = (isEureka = false) => {
+  if (isEureka) {
+    return sortBy(SECTION_PAGES.filter(({ isEurekaEnabled }) => isEurekaEnabled), ['label']);
+  }
+
+  return SECTION_PAGES;
+};

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -21,3 +21,5 @@ export const handleErrorMessages = ({
     type: 'error',
   });
 };
+
+export const isEurekaEnabled = (stripes) => stripes?.config?.isEureka;


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UICONSET-188](https://folio-org.atlassian.net/browse/UICONSET-188): ECS-NON-OKAPI Hide "Permission sets" subheading from consortia manager navigation
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

https://github.com/user-attachments/assets/c9aec36a-e6fd-421b-a17b-5e7fae426815


## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
