### PR TITLE
UICONSET-201 Hide create policy in consortium manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [UICONSET-173](https://folio-org.atlassian.net/browse/UICONSET-173) Share Authorization Roles for consortium.
 * [UICONSET-177](https://folio-org.atlassian.net/browse/UICONSET-177) Share Authorization Policies for consortium.
 * [UICONSET-190](https://folio-org.atlassian.net/browse/UICONSET-190) Update the filtering so it works the same for both authorization roles and policies.
+* [UICONSET-201](https://folio-org.atlassian.net/browse/UICONSET-201) Hide create policy action in "Consortium Manager".
 
 ## [1.1.0](https://github.com/folio-org/ui-consortia-settings/tree/v1.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v1.0.2...v1.1.0)

--- a/src/routes/ConsortiumManager/settings/authorization-policies/AuthorizationPoliciesSettings.js
+++ b/src/routes/ConsortiumManager/settings/authorization-policies/AuthorizationPoliciesSettings.js
@@ -12,6 +12,12 @@ import { AUTHORIZATION_POLICIES_ROUTE } from '../../../../constants';
 import { useMemberSelectionContext } from '../../MemberSelectionContext';
 import { AuthorizationPoliciesView } from './AuthorizationPoliciesView';
 
+/*
+  Create should be disabled for the current release.
+  https://folio-org.atlassian.net/browse/UICONSET-201
+*/
+const IS_POLICIES_FEATURE_ENABLED = false;
+
 export const AuthorizationPoliciesSettings = () => {
   const history = useHistory();
   const { activeMember } = useMemberSelectionContext();
@@ -23,32 +29,37 @@ export const AuthorizationPoliciesSettings = () => {
   return (
     <Router>
       <Switch>
-        <Route
-          exact
-          path={`${AUTHORIZATION_POLICIES_ROUTE}/create`}
-          render={() => (
-            <AffiliationLookupSuppressor>
-              <PolicyFormContainer
-                onClose={onClose}
-                path={AUTHORIZATION_POLICIES_ROUTE}
-                tenantId={activeMember}
-              />
-            </AffiliationLookupSuppressor>
-          )}
-        />
-        <Route
-          exact
-          path={`${AUTHORIZATION_POLICIES_ROUTE}/:id/edit`}
-          render={() => (
-            <AffiliationLookupSuppressor>
-              <PolicyFormContainer
-                onClose={onClose}
-                path={AUTHORIZATION_POLICIES_ROUTE}
-                tenantId={activeMember}
-              />
-            </AffiliationLookupSuppressor>
-          )}
-        />
+        {IS_POLICIES_FEATURE_ENABLED && (
+          <>
+            <Route
+              exact
+              path={`${AUTHORIZATION_POLICIES_ROUTE}/create`}
+              render={() => (
+                <AffiliationLookupSuppressor>
+                  <PolicyFormContainer
+                    onClose={onClose}
+                    path={AUTHORIZATION_POLICIES_ROUTE}
+                    tenantId={activeMember}
+                  />
+                </AffiliationLookupSuppressor>
+              )}
+            />
+            <Route
+              exact
+              path={`${AUTHORIZATION_POLICIES_ROUTE}/:id/edit`}
+              render={() => (
+                <AffiliationLookupSuppressor>
+                  <PolicyFormContainer
+                    onClose={onClose}
+                    path={AUTHORIZATION_POLICIES_ROUTE}
+                    tenantId={activeMember}
+                  />
+                </AffiliationLookupSuppressor>
+              )}
+            />
+          </>
+        )}
+
         <Route
           exact
           path={`${AUTHORIZATION_POLICIES_ROUTE}/:id?`}

--- a/src/routes/ConsortiumManager/settings/authorization-policies/AuthorizationPoliciesSettings.test.js
+++ b/src/routes/ConsortiumManager/settings/authorization-policies/AuthorizationPoliciesSettings.test.js
@@ -65,14 +65,14 @@ describe('AuthorizationPoliciesSettings', () => {
     expect(pageTitle).toBeInTheDocument();
   });
 
-  it('should display create authorization policy create page', () => {
+  xit('should display create authorization policy create page', () => {
     window.location.pathname = `${pathname}/create`;
     renderComponent();
 
     expect(screen.getByText('PolicyFormContainer')).toBeInTheDocument();
   });
 
-  it('should display edit authorization policy edit page', () => {
+  xit('should display edit authorization policy edit page', () => {
     window.location.pathname = `${pathname}/1/edit`;
     renderComponent();
 

--- a/src/routes/ConsortiumManager/settings/authorization-policies/AuthorizationPoliciesView.js
+++ b/src/routes/ConsortiumManager/settings/authorization-policies/AuthorizationPoliciesView.js
@@ -42,6 +42,12 @@ import {
 } from './constants';
 import { getResultsFormatter } from './utils';
 
+/*
+  Create should be disabled for the current release.
+  https://folio-org.atlassian.net/browse/UICONSET-201
+*/
+const IS_POLICIES_FEATURE_ENABLED = false;
+
 export const AuthorizationPoliciesView = () => {
   const history = useHistory();
   const location = useLocation();
@@ -87,7 +93,7 @@ export const AuthorizationPoliciesView = () => {
 
   const formatter = useMemo(() => getResultsFormatter({ users }), [users]);
 
-  const lastMenu = (
+  const lastMenu = IS_POLICIES_FEATURE_ENABLED && (
     <PaneMenu>
       <IfPermission perm="policies.item.post">
         <Button


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

https://folio-org.atlassian.net/browse/UICONSET-201

We need to hide the ability to create/edit/share authorization policy in the Consortium manager, until this functionality will be implemented in the Settings page. So this functionality will be disabled for Ramsons and should be enabled again in the Sunflower release.