### PR TITLE
UICONSET-206: ECS | Eureka | Request to central tenant instead of member when compare users in "Consortium manager"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [UICONSET-196](https://folio-org.atlassian.net/browse/UICONSET-196) Save consortium-wide settings for Inventory - Instances - Subject types.
 * [UICONSET-197](https://folio-org.atlassian.net/browse/UICONSET-197) Allow user to share Inventory - Instances - Subject types.
 * [UICONSET-204](https://folio-org.atlassian.net/browse/UICONSET-204) Refactor ui-inventory permissions.
+* [UICONSET-206](https://folio-org.atlassian.net/browse/UICONSET-206) ECS | Eureka | Request to central tenant instead of member when compare users in "Consortium manager".
 
 ## [1.1.0](https://github.com/folio-org/ui-consortia-settings/tree/v1.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v1.0.2...v1.1.0)

--- a/src/routes/ConsortiumManager/settings/authorization-roles/Capabilities/CapabilitiesCompareItem/CapabilitiesCompareItem.js
+++ b/src/routes/ConsortiumManager/settings/authorization-roles/Capabilities/CapabilitiesCompareItem/CapabilitiesCompareItem.js
@@ -73,7 +73,7 @@ export const CapabilitiesCompareItem = ({
     isSuccess: isSuccessCapabilities,
     initialRoleCapabilitiesSelectedMap,
     groupedRoleCapabilitiesByType,
-  } = useRoleCapabilities(selectedRoleId, selectedMemberId);
+  } = useRoleCapabilities(selectedRoleId, selectedMemberId, true);
 
   useEffect(() => {
     if (isMounted.current && isSuccessCapabilitiesSet && isSuccessCapabilities) {

--- a/src/routes/ConsortiumManager/settings/authorization-roles/UsersCapabilities/UsersCapabilitiesCompareItems/UsersCapabilitiesCompareItems.js
+++ b/src/routes/ConsortiumManager/settings/authorization-roles/UsersCapabilities/UsersCapabilitiesCompareItems/UsersCapabilitiesCompareItems.js
@@ -90,7 +90,7 @@ export const UsersCapabilitiesCompareItems = ({
     isSuccess: isSuccessCapabilities,
     initialUserCapabilitiesSelectedMap,
     groupedUserCapabilitiesByType,
-  } = useUserCapabilities(selectedUserId, selectedMemberId);
+  } = useUserCapabilities(selectedUserId, selectedMemberId, true);
 
   const {
     groupedUserCapabilitySetsByType,
@@ -109,7 +109,7 @@ export const UsersCapabilitiesCompareItems = ({
     capabilitiesTotalCount: capabilitiesByRoleCountTotal,
     groupedRoleCapabilitiesByType,
     isSuccess: isSuccessRoleCapabilities,
-  } = useRoleCapabilities(selectedRoleId, selectedMemberId);
+  } = useRoleCapabilities(selectedRoleId, selectedMemberId, true);
 
   useEffect(() => {
     if (isMounted.current &&

--- a/src/routes/ConsortiumManager/settings/authorization-roles/UsersCapabilities/UsersCapabilitiesCompareItems/UsersCapabilitiesCompareItems.js
+++ b/src/routes/ConsortiumManager/settings/authorization-roles/UsersCapabilities/UsersCapabilitiesCompareItems/UsersCapabilitiesCompareItems.js
@@ -24,7 +24,7 @@ import {
   useRoleCapabilitySets,
   useUserCapabilities,
   useUserCapabilitiesSets,
-  useUserRolesByUserIds,
+  useUserRolesById,
 } from '@folio/stripes-authorization-components';
 
 import { handleErrorMessages } from '../../../../../../utils';
@@ -56,7 +56,7 @@ export const UsersCapabilitiesCompareItems = ({
       messageId: 'ui-consortia-settings.authorizationRoles.errors.loading.users',
     }),
   });
-  const { userRolesResponse } = useUserRolesByUserIds([selectedUserId]);
+  const { userRolesResponse } = useUserRolesById(selectedUserId, { tenantId: selectedMemberId });
   const { roles, isLoading } = useAuthorizationRoles(selectedMemberId, {
     onError: ({ response }) => handleErrorMessages({
       intl,

--- a/src/routes/ConsortiumManager/settings/authorization-roles/UsersCapabilities/UsersCapabilitiesCompareItems/UsersCapabilitiesCompareItems.test.js
+++ b/src/routes/ConsortiumManager/settings/authorization-roles/UsersCapabilities/UsersCapabilitiesCompareItems/UsersCapabilitiesCompareItems.test.js
@@ -11,7 +11,7 @@ import {
   useRoleCapabilitySets,
   useUserCapabilities,
   useUserCapabilitiesSets,
-  useUserRolesByUserIds,
+  useUserRolesById,
 } from '@folio/stripes-authorization-components';
 
 import {
@@ -30,7 +30,7 @@ jest.mock('@folio/stripes-authorization-components', () => ({
   useUserCapabilities: jest.fn(),
   useUserCapabilitiesSets: jest.fn(),
   useAuthorizationRoles: jest.fn(),
-  useUserRolesByUserIds: jest.fn(),
+  useUserRolesById: jest.fn(),
   useRoleCapabilities: jest.fn(),
   useRoleCapabilitySets: jest.fn(),
 }));
@@ -96,7 +96,7 @@ describe('UsersCapabilitiesCompareItems', () => {
     useUsers.mockClear().mockReturnValue({
       users,
     });
-    useUserRolesByUserIds.mockClear().mockReturnValue({
+    useUserRolesById.mockClear().mockReturnValue({
       userRolesResponse,
     });
     useUserCapabilitiesSets.mockClear().mockReturnValue({


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UICONSET-206

Here we changed the logic of fetching `roles` for users from different members. Note: `capabilities` and `capabilities set` requests on video falling coz env was rebuilt without the required permissions for members

https://github.com/user-attachments/assets/cb2135f8-4812-4e0f-96e8-7aa8b2b31acd

